### PR TITLE
feat: display Bitcoin address and LN invoice in uppercase in QR codes

### DIFF
--- a/src/app/receive-btc/_layout.tsx
+++ b/src/app/receive-btc/_layout.tsx
@@ -153,7 +153,7 @@ export default function ReceivePaymentScreen() {
           <ScrollView className="flex-1" showsVerticalScrollIndicator={false}>
             <View className="mb-8 items-center">
               <View className="p-6">
-                <QRCode value={addAmountAndNoteToAddress(address, amount, note)} size={220} backgroundColor="white" color="black" />
+                <QRCode value={addAmountAndNoteToAddress(address?.toUpperCase(), amount, note)} size={220} backgroundColor="white" color="black" />
               </View>
               <Text className="mt-4 text-center text-sm text-gray-500">{t('receive_onchain.scan_text')}</Text>
             </View>
@@ -172,7 +172,7 @@ export default function ReceivePaymentScreen() {
               </View>
             </View>
             <Pressable onPress={copyToClipboard} className="mx-4 flex flex-row flex-wrap justify-center">
-              {splitStringIntoChunks(address, 6).map((s) => (
+              {splitStringIntoChunks(address?.toUpperCase(), 6).map((s) => (
                 <View className="m-2" key={s}>
                   <Text className="text-base font-bold text-primary-600">{s}</Text>
                 </View>

--- a/src/app/receive/ln-qrcode.tsx
+++ b/src/app/receive/ln-qrcode.tsx
@@ -180,10 +180,10 @@ export default function ReceivePaymentScreen() {
               </View>
             )}
             <View className="mb-8 items-center">
-              <View className="bg-white p-6">{paymentRequest && <QRCode value={paymentRequest} size={200} backgroundColor="white" color="black" />}</View>
+              <View className="bg-white p-6">{paymentRequest && <QRCode value={paymentRequest?.toUpperCase()} size={200} backgroundColor="white" color="black" />}</View>
               {type === 'onchain' && (
                 <Pressable onPress={copyToClipboard} className="mx-4 flex flex-row flex-wrap justify-center">
-                  {splitStringIntoChunks(paymentRequest, 6).map((s) => (
+                  {splitStringIntoChunks(paymentRequest?.toUpperCase(), 6).map((s) => (
                     <View className="m-2" key={s}>
                       <Text className="text-base font-bold text-primary-600">{s}</Text>
                     </View>


### PR DESCRIPTION
## What does this do?

Displays Bitcoin addresses and Lightning Network (LN) invoices in uppercase when generating QR codes.

## Why did you do this?

Ensures better readability and compatibility when scanning QR codes, as some QR code readers may have issues with lowercase characters.

## Who/what does this impact?

This change affects any feature that generates or displays Bitcoin addresses or LN invoices as QR codes. It may impact users scanning these codes and any downstream processes relying on QR code data.

## How did you test this?

Tested by generating QR codes for both Bitcoin addresses and LN invoices and verifying that the displayed data is in uppercase and scannable by standard QR code readers.

<img width="1080" height="2400" alt="Screenshot_1774021819" src="https://github.com/user-attachments/assets/79411dd5-fb1e-4bd5-b7e7-69216be2c65d" />
