### PR TITLE
feat: add Lightning payment flow with amount entry and transaction de…

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "react-native-web": "~0.20.0",
     "react-query-kit": "^3.3.0",
     "tailwind-variants": "^0.2.1",
-    "validator": "^13.15.22",
     "zod": "^3.23.8",
     "zustand": "^4.5.5"
   },
@@ -114,7 +113,6 @@
     "@types/jest": "^29.5.12",
     "@types/lodash.memoize": "^4.1.9",
     "@types/react": "~19.0.14",
-    "@types/validator": "^13.15.3",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
     "babel-plugin-module-resolver": "^5.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,9 +191,6 @@ importers:
       tailwind-variants:
         specifier: ^0.2.1
         version: 0.2.1(tailwindcss@3.4.4)
-      validator:
-        specifier: ^13.15.22
-        version: 13.15.26
       zod:
         specifier: ^3.23.8
         version: 3.23.8
@@ -237,9 +234,6 @@ importers:
       '@types/react':
         specifier: ~19.0.14
         version: 19.0.14
-      '@types/validator':
-        specifier: ^13.15.3
-        version: 13.15.3
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.62.0
         version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.8.3))(eslint@8.57.0)(typescript@5.8.3)
@@ -1785,9 +1779,6 @@ packages:
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
-
-  '@types/validator@13.15.3':
-    resolution: {integrity: sha512-7bcUmDyS6PN3EuD9SlGGOxM77F8WLVsrwkxyWxKnxzmXoequ6c7741QBrANq6htVRGOITJ7z72mTP6Z4XyuG+Q==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -7025,10 +7016,6 @@ packages:
     resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
-  validator@13.15.26:
-    resolution: {integrity: sha512-spH26xU080ydGggxRyR1Yhcbgx+j3y5jbNXk/8L+iRvdIEQ4uTRH2Sgf2dokud6Q4oAtsbNvJ1Ft+9xmm6IZcA==}
-    engines: {node: '>= 0.10'}
-
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
@@ -9430,8 +9417,6 @@ snapshots:
   '@types/stack-utils@2.0.3': {}
 
   '@types/tough-cookie@4.0.5': {}
-
-  '@types/validator@13.15.3': {}
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -15497,8 +15482,6 @@ snapshots:
       spdx-expression-parse: 3.0.1
 
   validate-npm-package-name@5.0.1: {}
-
-  validator@13.15.26: {}
 
   vary@1.1.2: {}
 

--- a/src/app/send/__tests__/enter-address.test.tsx
+++ b/src/app/send/__tests__/enter-address.test.tsx
@@ -143,19 +143,19 @@ describe('LightningPaymentScreen (enter-address)', () => {
     it('navigates to enter-amount for LightningAddress type', async () => {
       mockParseInput.mockResolvedValueOnce({
         tag: 'LightningAddress',
-        inner: [{ address: 'alice@getalby.com', payRequest: {} }],
+        inner: [{ address: 'alice@pay.usegrimm.app', payRequest: {} }],
       });
 
       const { user } = setup(<LightningPaymentScreen />);
       const input = screen.getByPlaceholderText('lightningPayment.placeholder');
 
-      fireEvent.changeText(input, 'alice@getalby.com');
+      fireEvent.changeText(input, 'alice@pay.usegrimm.app');
       await user.press(screen.getByText('lightningPayment.payButton'));
 
       await waitFor(() => {
         expect(mockPush).toHaveBeenCalledWith({
           pathname: '/send/enter-amount',
-          params: { lightningAddress: 'alice@getalby.com' },
+          params: { paymentInput: 'alice@pay.usegrimm.app' },
         });
       });
     });
@@ -175,7 +175,7 @@ describe('LightningPaymentScreen (enter-address)', () => {
       await waitFor(() => {
         expect(mockPush).toHaveBeenCalledWith({
           pathname: '/send/enter-amount',
-          params: { lightningAddress: 'lnurl1...' },
+          params: { paymentInput: 'lnurl1...' },
         });
       });
     });

--- a/src/app/send/__tests__/enter-address.test.tsx
+++ b/src/app/send/__tests__/enter-address.test.tsx
@@ -1,0 +1,248 @@
+import React from 'react';
+
+import { cleanup, fireEvent, screen, setup, waitFor } from '@/lib/test-utils';
+import LightningPaymentScreen from '../enter-address';
+
+const mockPush = jest.fn();
+const mockBack = jest.fn();
+const mockParseInput = jest.fn();
+const mockShowErrorMessage = jest.fn();
+
+jest.mock('react-native-safe-area-context', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    SafeAreaProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    SafeAreaView: ({ children, ...props }: { children: React.ReactNode }) => <View {...props}>{children}</View>,
+    useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 0, left: 0 }),
+  };
+});
+
+jest.mock('@expo/vector-icons/Ionicons', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return (props: Record<string, unknown>) => <View {...props} />;
+});
+
+jest.mock('@/components/ui/focus-aware-status-bar', () => ({
+  FocusAwareStatusBar: () => null,
+}));
+
+jest.mock('react-i18next', () => ({
+  initReactI18next: {
+    type: '3rdParty',
+    init: jest.fn(),
+  },
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+jest.mock('@/lib/i18n', () => ({
+  translate: (key: string) => key,
+}));
+
+jest.mock('expo-router', () => {
+  const React = require('react');
+  return {
+    useRouter: () => ({
+      push: mockPush,
+      back: mockBack,
+    }),
+    useLocalSearchParams: () => ({}),
+    Stack: {
+      Screen: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    },
+  };
+});
+
+jest.mock('@/lib/context/breez-context', () => ({
+  useBreez: () => ({
+    parseInput: mockParseInput,
+  }),
+  InputType_Tags: {
+    BitcoinAddress: 'BitcoinAddress',
+    Bolt11Invoice: 'Bolt11Invoice',
+    LnurlPay: 'LnurlPay',
+    LightningAddress: 'LightningAddress',
+  },
+}));
+
+jest.mock('@/components/ui/utils', () => ({
+  showErrorMessage: (...args: unknown[]) => mockShowErrorMessage(...args),
+}));
+
+afterEach(() => {
+  cleanup();
+  jest.clearAllMocks();
+});
+
+describe('LightningPaymentScreen (enter-address)', () => {
+  describe('Rendering', () => {
+    it('renders the input field and button', () => {
+      setup(<LightningPaymentScreen />);
+
+      expect(screen.getByPlaceholderText('lightningPayment.placeholder')).toBeOnTheScreen();
+      expect(screen.getByText('lightningPayment.payButton')).toBeOnTheScreen();
+    });
+  });
+
+  describe('Empty input', () => {
+    it('shows error when input is empty and button is pressed', async () => {
+      const { user } = setup(<LightningPaymentScreen />);
+
+      const button = screen.getByText('lightningPayment.payButton');
+      await user.press(button);
+
+      expect(mockShowErrorMessage).toHaveBeenCalledWith('lightningPayment.errors.invalidInvoice');
+      expect(mockParseInput).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Bolt11 Invoice', () => {
+    it('navigates to transaction-details for valid Bolt11 invoice', async () => {
+      mockParseInput.mockResolvedValueOnce({
+        tag: 'Bolt11Invoice',
+        inner: [{ amountMsat: 5000000n, invoice: { bolt11: 'lnbc1...' } }],
+      });
+
+      const { user } = setup(<LightningPaymentScreen />);
+      const input = screen.getByPlaceholderText('lightningPayment.placeholder');
+
+      fireEvent.changeText(input, 'lnbc1...');
+      await user.press(screen.getByText('lightningPayment.payButton'));
+
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith({
+          pathname: '/send/transaction-details',
+          params: { rawInvoice: 'lnbc1...' },
+        });
+      });
+    });
+
+    it('shows error for zero-amount Bolt11 invoice', async () => {
+      mockParseInput.mockResolvedValueOnce({
+        tag: 'Bolt11Invoice',
+        inner: [{ amountMsat: undefined, invoice: { bolt11: 'lnbc1...' } }],
+      });
+
+      const { user } = setup(<LightningPaymentScreen />);
+      const input = screen.getByPlaceholderText('lightningPayment.placeholder');
+
+      fireEvent.changeText(input, 'lnbc1...');
+      await user.press(screen.getByText('lightningPayment.payButton'));
+
+      await waitFor(() => {
+        expect(mockShowErrorMessage).toHaveBeenCalledWith('lightningPayment.errors.zeroAmountNotSupported');
+      });
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Lightning Address', () => {
+    it('navigates to enter-amount for LightningAddress type', async () => {
+      mockParseInput.mockResolvedValueOnce({
+        tag: 'LightningAddress',
+        inner: [{ address: 'alice@getalby.com', payRequest: {} }],
+      });
+
+      const { user } = setup(<LightningPaymentScreen />);
+      const input = screen.getByPlaceholderText('lightningPayment.placeholder');
+
+      fireEvent.changeText(input, 'alice@getalby.com');
+      await user.press(screen.getByText('lightningPayment.payButton'));
+
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith({
+          pathname: '/send/enter-amount',
+          params: { lightningAddress: 'alice@getalby.com' },
+        });
+      });
+    });
+
+    it('navigates to enter-amount for LnurlPay type', async () => {
+      mockParseInput.mockResolvedValueOnce({
+        tag: 'LnurlPay',
+        inner: [{ callback: 'https://usegrimm.app' }],
+      });
+
+      const { user } = setup(<LightningPaymentScreen />);
+      const input = screen.getByPlaceholderText('lightningPayment.placeholder');
+
+      fireEvent.changeText(input, 'lnurl1...');
+      await user.press(screen.getByText('lightningPayment.payButton'));
+
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith({
+          pathname: '/send/enter-amount',
+          params: { lightningAddress: 'lnurl1...' },
+        });
+      });
+    });
+  });
+
+  describe('Bitcoin Address', () => {
+    it('shows error for bitcoin address', async () => {
+      mockParseInput.mockResolvedValueOnce({
+        tag: 'BitcoinAddress',
+        inner: [{ address: 'bc1q...' }],
+      });
+
+      const { user } = setup(<LightningPaymentScreen />);
+      const input = screen.getByPlaceholderText('lightningPayment.placeholder');
+
+      fireEvent.changeText(input, 'bc1q...');
+      await user.press(screen.getByText('lightningPayment.payButton'));
+
+      await waitFor(() => {
+        expect(mockShowErrorMessage).toHaveBeenCalledWith('lightningPayment.errors.bitcoinNotSupported');
+      });
+    });
+  });
+
+  describe('Unsupported input', () => {
+    it('shows error for unsupported address type', async () => {
+      mockParseInput.mockResolvedValueOnce({
+        tag: 'UnknownType',
+        inner: [],
+      });
+
+      const { user } = setup(<LightningPaymentScreen />);
+      const input = screen.getByPlaceholderText('lightningPayment.placeholder');
+
+      fireEvent.changeText(input, 'something-unknown');
+      await user.press(screen.getByText('lightningPayment.payButton'));
+
+      await waitFor(() => {
+        expect(mockShowErrorMessage).toHaveBeenCalledWith('lightningPayment.errors.unsupportedAddress');
+      });
+    });
+  });
+
+  describe('Error handling', () => {
+    it('shows error when parseInput throws', async () => {
+      mockParseInput.mockRejectedValueOnce(new Error('Network error'));
+
+      const { user } = setup(<LightningPaymentScreen />);
+      const input = screen.getByPlaceholderText('lightningPayment.placeholder');
+
+      fireEvent.changeText(input, 'some-invalid-input');
+      await user.press(screen.getByText('lightningPayment.payButton'));
+
+      await waitFor(() => {
+        expect(mockShowErrorMessage).toHaveBeenCalledWith('lightningPayment.errors.preparePaymentFailed');
+      });
+    });
+  });
+
+  describe('Input change', () => {
+    it('updates input value when typing', () => {
+      setup(<LightningPaymentScreen />);
+      const input = screen.getByPlaceholderText('lightningPayment.placeholder');
+
+      fireEvent.changeText(input, 'new-input-value');
+
+      expect(input.props.value).toBe('new-input-value');
+    });
+  });
+});

--- a/src/app/send/__tests__/enter-amount.test.tsx
+++ b/src/app/send/__tests__/enter-amount.test.tsx
@@ -57,7 +57,7 @@ jest.mock('expo-router', () => {
       back: mockBack,
     }),
     useLocalSearchParams: () => ({
-      lightningAddress: 'alice@getalby.com',
+      paymentInput: 'alice@pay.usegrimm.app',
     }),
     Stack: {
       Screen: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
@@ -116,7 +116,7 @@ describe('LightningAddressAmountScreen (enter-amount)', () => {
       setup(<LightningAddressAmountScreen />);
 
       expect(screen.getByText(/enterAmount.sendTo/)).toBeOnTheScreen();
-      expect(screen.getByText(/alice@getalby.com/)).toBeOnTheScreen();
+      expect(screen.getByText(/alice@pay.usegrimm.app/)).toBeOnTheScreen();
     });
 
     it('renders the numeric keypad keys', () => {
@@ -187,7 +187,7 @@ describe('LightningAddressAmountScreen (enter-amount)', () => {
         expect(mockPush).toHaveBeenCalledWith({
           pathname: '/send/transaction-details',
           params: {
-            lightningAddress: 'alice@getalby.com',
+            paymentInput: 'alice@pay.usegrimm.app',
             amountSats: '5432',
           },
         });

--- a/src/app/send/__tests__/enter-amount.test.tsx
+++ b/src/app/send/__tests__/enter-amount.test.tsx
@@ -1,0 +1,237 @@
+import React from 'react';
+
+import { cleanup, fireEvent, screen, setup, waitFor } from '@/lib/test-utils';
+
+import LightningAddressAmountScreen from '../enter-amount';
+
+const mockPush = jest.fn();
+const mockBack = jest.fn();
+
+jest.mock('react-native-safe-area-context', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    SafeAreaProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    SafeAreaView: ({ children, ...props }: { children: React.ReactNode }) => <View {...props}>{children}</View>,
+    useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 0, left: 0 }),
+  };
+});
+
+jest.mock('@expo/vector-icons/Ionicons', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return (props: Record<string, unknown>) => <View {...props} />;
+});
+
+jest.mock('@expo/vector-icons', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    MaterialCommunityIcons: (props: Record<string, unknown>) => <View {...props} />,
+  };
+});
+
+jest.mock('@/components/ui/focus-aware-status-bar', () => ({
+  FocusAwareStatusBar: () => null,
+}));
+
+jest.mock('react-i18next', () => ({
+  initReactI18next: {
+    type: '3rdParty',
+    init: jest.fn(),
+  },
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+jest.mock('@/lib/i18n', () => ({
+  translate: (key: string) => key,
+}));
+
+jest.mock('expo-router', () => {
+  const React = require('react');
+  return {
+    useRouter: () => ({
+      push: mockPush,
+      back: mockBack,
+    }),
+    useLocalSearchParams: () => ({
+      lightningAddress: 'alice@getalby.com',
+    }),
+    Stack: {
+      Screen: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    },
+  };
+});
+
+jest.mock('@/lib/context/breez-context', () => ({
+  useBreez: () => ({
+    balance: 100000,
+  }),
+}));
+
+jest.mock('@/lib/context', () => {
+  const React = require('react');
+  return {
+    AppContext: React.createContext({
+      bitcoinUnit: 'SATS',
+      selectedCountry: { name: 'United States', code: 'US', currency: 'USD' },
+    }),
+  };
+});
+
+jest.mock('@/lib/context/bitcoin-prices-context', () => ({
+  useBitcoin: () => ({
+    bitcoinPrices: { BTC: { USD: 50000 } },
+  }),
+}));
+
+jest.mock('@/lib', () => ({
+  convertBitcoinToFiat: (amount: number) => amount * 0.0005,
+  convertBtcToSats: (btc: number) => Math.round(btc * 1e8),
+  getFiatCurrency: () => 'USD',
+}));
+
+afterEach(() => {
+  cleanup();
+  jest.clearAllMocks();
+});
+
+describe('LightningAddressAmountScreen (enter-amount)', () => {
+  const pressKeypadDigit = async (user: ReturnType<typeof import('@testing-library/react-native').userEvent.setup>, digit: string) => {
+    const elements = screen.getAllByText(digit);
+    await user.press(elements[elements.length - 1]);
+  };
+
+  describe('Rendering', () => {
+    it('renders the amount display and keypad', () => {
+      setup(<LightningAddressAmountScreen />);
+
+      expect(screen.getAllByText('0').length).toBeGreaterThanOrEqual(2); // amount display + keypad
+      expect(screen.getByText('enterAmount.continueButton')).toBeOnTheScreen();
+    });
+
+    it('renders the send-to label with the lightning address', () => {
+      setup(<LightningAddressAmountScreen />);
+
+      expect(screen.getByText(/enterAmount.sendTo/)).toBeOnTheScreen();
+      expect(screen.getByText(/alice@getalby.com/)).toBeOnTheScreen();
+    });
+
+    it('renders the numeric keypad keys', () => {
+      setup(<LightningAddressAmountScreen />);
+
+      for (const key of ['1', '2', '3', '4', '5', '6', '7', '8', '9']) {
+        expect(screen.getByText(key)).toBeOnTheScreen();
+      }
+      // '0' appears multiple times (keypad + amount display)
+      expect(screen.getAllByText('0').length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('renders the bitcoin unit label', () => {
+      setup(<LightningAddressAmountScreen />);
+
+      expect(screen.getByText('SATS')).toBeOnTheScreen();
+    });
+  });
+
+  describe('Numeric keypad interaction', () => {
+    it('updates amount when pressing number keys', async () => {
+      const { user } = setup(<LightningAddressAmountScreen />);
+
+      await pressKeypadDigit(user, '5');
+
+      await waitFor(() => {
+        expect(screen.getAllByText('5').length).toBeGreaterThanOrEqual(1);
+      });
+    });
+
+    it('builds multi-digit amounts', async () => {
+      const { user } = setup(<LightningAddressAmountScreen />);
+
+      await pressKeypadDigit(user, '1');
+      await pressKeypadDigit(user, '2');
+      await pressKeypadDigit(user, '3');
+
+      await waitFor(() => {
+        expect(screen.getByText('123')).toBeOnTheScreen();
+      });
+    });
+
+    it('handles delete key', async () => {
+      const { user } = setup(<LightningAddressAmountScreen />);
+
+      await pressKeypadDigit(user, '5');
+      await pressKeypadDigit(user, '3');
+      await user.press(screen.getByTestId('delete-key'));
+
+      await waitFor(() => {
+        expect(screen.getAllByText('5').length).toBeGreaterThanOrEqual(1);
+      });
+    });
+  });
+
+  describe('Navigation', () => {
+    it('navigates to transaction-details with correct params on continue', async () => {
+      const { user } = setup(<LightningAddressAmountScreen />);
+
+      await pressKeypadDigit(user, '5');
+      await pressKeypadDigit(user, '4');
+      await pressKeypadDigit(user, '3');
+      await pressKeypadDigit(user, '2');
+
+      await user.press(screen.getByText('enterAmount.continueButton'));
+
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith({
+          pathname: '/send/transaction-details',
+          params: {
+            lightningAddress: 'alice@getalby.com',
+            amountSats: '5432',
+          },
+        });
+      });
+    });
+
+    it('does not navigate when amount is zero', async () => {
+      const { user } = setup(<LightningAddressAmountScreen />);
+
+      await user.press(screen.getByText('enterAmount.continueButton'));
+
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Balance validation', () => {
+    it('shows insufficient balance message when amount exceeds balance', async () => {
+      const { user } = setup(<LightningAddressAmountScreen />);
+
+      // Enter amount > 100000 (balance) by pressing distinct digits to avoid conflicts
+      await pressKeypadDigit(user, '9');
+      await pressKeypadDigit(user, '9');
+      await pressKeypadDigit(user, '9');
+      await pressKeypadDigit(user, '9');
+      await pressKeypadDigit(user, '9');
+      await pressKeypadDigit(user, '9');
+
+      await waitFor(() => {
+        expect(screen.getByText('enterAmount.insufficientBalance')).toBeOnTheScreen();
+      });
+    });
+  });
+
+  describe('Fiat conversion', () => {
+    it('displays fiat amount when a valid amount is entered', async () => {
+      const { user } = setup(<LightningAddressAmountScreen />);
+
+      await pressKeypadDigit(user, '1');
+      await pressKeypadDigit(user, '2');
+      await pressKeypadDigit(user, '3');
+
+      await waitFor(() => {
+        expect(screen.getByText('USD')).toBeOnTheScreen();
+      });
+    });
+  });
+});

--- a/src/app/send/__tests__/transaction-details.test.tsx
+++ b/src/app/send/__tests__/transaction-details.test.tsx
@@ -259,7 +259,7 @@ describe('PaymentDetailsScreen (transaction-details)', () => {
 
   describe('Lightning Address flow', () => {
     it('displays LN address as destination', async () => {
-      mockSearchParams = { lightningAddress: 'bob@pay.usegrimm.app', amountSats: '5000' };
+      mockSearchParams = { paymentInput: 'bob@pay.usegrimm.app', amountSats: '5000' };
       mockParseInput.mockResolvedValueOnce({
         tag: 'LightningAddress',
         inner: [{ address: 'bob@pay.usegrimm.app', payRequest: { callback: 'https://getalby.com/lnurlp/alice' } }],
@@ -279,7 +279,7 @@ describe('PaymentDetailsScreen (transaction-details)', () => {
     });
 
     it('handles LnurlPay input type', async () => {
-      mockSearchParams = { lightningAddress: 'lnurl1...', amountSats: '3000' };
+      mockSearchParams = { paymentInput: 'lnurl1...', amountSats: '3000' };
       mockParseInput.mockResolvedValueOnce({
         tag: 'LnurlPay',
         inner: [{ callback: 'https://usegrimm.app/lnurlp' }],
@@ -297,7 +297,7 @@ describe('PaymentDetailsScreen (transaction-details)', () => {
     });
 
     it('shows decode error for unsupported parsed type', async () => {
-      mockSearchParams = { lightningAddress: 'bad@pay.usegrimm.app', amountSats: '1000' };
+      mockSearchParams = { paymentInput: 'bad@pay.usegrimm.app', amountSats: '1000' };
       mockParseInput.mockResolvedValueOnce({
         tag: 'BitcoinAddress',
         inner: [{ address: 'bc1q...' }],
@@ -311,7 +311,7 @@ describe('PaymentDetailsScreen (transaction-details)', () => {
     });
 
     it('shows not enough funds error for LN address', async () => {
-      mockSearchParams = { lightningAddress: 'bob@pay.usegrimm.app', amountSats: '5000' };
+      mockSearchParams = { paymentInput: 'bob@pay.usegrimm.app', amountSats: '5000' };
       mockParseInput.mockResolvedValueOnce({
         tag: 'LightningAddress',
         inner: [{ address: 'bob@pay.usegrimm.app', payRequest: {} }],
@@ -326,7 +326,7 @@ describe('PaymentDetailsScreen (transaction-details)', () => {
     });
 
     it('shows invalidData error for generic LN address failure', async () => {
-      mockSearchParams = { lightningAddress: 'bob@pay.usegrimm.app', amountSats: '5000' };
+      mockSearchParams = { paymentInput: 'bob@pay.usegrimm.app', amountSats: '5000' };
       mockParseInput.mockResolvedValueOnce({
         tag: 'LightningAddress',
         inner: [{ address: 'bob@pay.usegrimm.app', payRequest: {} }],
@@ -336,12 +336,12 @@ describe('PaymentDetailsScreen (transaction-details)', () => {
       setup(<PaymentDetailsScreen />);
 
       await waitFor(() => {
-        expect(mockShowErrorMessage).toHaveBeenCalledWith('paymentDetails.errors.invalidData');
+        expect(screen.getByText('paymentDetails.errorMessage')).toBeOnTheScreen();
       });
     });
 
     it('executes LNURL payment on confirm', async () => {
-      mockSearchParams = { lightningAddress: 'bob@pay.usegrimm.app', amountSats: '5000' };
+      mockSearchParams = { paymentInput: 'bob@pay.usegrimm.app', amountSats: '5000' };
       const mockLnurlPrepareResponse = {
         amountSats: 5000n,
         feeSats: 10n,
@@ -372,7 +372,7 @@ describe('PaymentDetailsScreen (transaction-details)', () => {
     });
 
     it('does not show expiry timer for LN address', async () => {
-      mockSearchParams = { lightningAddress: 'bob@pay.usegrimm.app', amountSats: '5000' };
+      mockSearchParams = { paymentInput: 'bob@pay.usegrimm.app', amountSats: '5000' };
       mockParseInput.mockResolvedValueOnce({
         tag: 'LightningAddress',
         inner: [{ address: 'bob@pay.usegrimm.app', payRequest: {} }],

--- a/src/app/send/__tests__/transaction-details.test.tsx
+++ b/src/app/send/__tests__/transaction-details.test.tsx
@@ -1,0 +1,469 @@
+import React from 'react';
+
+import { cleanup, screen, setup, waitFor } from '@/lib/test-utils';
+
+import PaymentDetailsScreen from '../transaction-details';
+
+const mockPush = jest.fn();
+const mockBack = jest.fn();
+const mockParseInput = jest.fn();
+const mockPrepareSend = jest.fn();
+const mockExecuteSend = jest.fn();
+const mockPrepareLnurlPay = jest.fn();
+const mockExecuteLnurlPay = jest.fn();
+const mockShowErrorMessage = jest.fn();
+
+let mockSearchParams: Record<string, string | undefined> = {};
+
+jest.mock('react-native-safe-area-context', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    SafeAreaProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    SafeAreaView: ({ children, ...props }: { children: React.ReactNode }) => <View {...props}>{children}</View>,
+    useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 0, left: 0 }),
+  };
+});
+
+jest.mock('@expo/vector-icons/build/Ionicons', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return (props: Record<string, unknown>) => <View {...props} />;
+});
+
+jest.mock('@/components/ui/focus-aware-status-bar', () => ({
+  FocusAwareStatusBar: () => null,
+}));
+
+jest.mock('react-i18next', () => ({
+  initReactI18next: {
+    type: '3rdParty',
+    init: jest.fn(),
+  },
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+jest.mock('@/lib/i18n', () => ({
+  translate: (key: string) => key,
+}));
+
+jest.mock('expo-router', () => {
+  const React = require('react');
+  return {
+    useRouter: () => ({
+      push: mockPush,
+      back: mockBack,
+    }),
+    useLocalSearchParams: () => mockSearchParams,
+    Stack: {
+      Screen: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    },
+  };
+});
+
+jest.mock('@/lib/context/breez-context', () => ({
+  useBreez: () => ({
+    parseInput: mockParseInput,
+    prepareSend: mockPrepareSend,
+    executeSend: mockExecuteSend,
+    prepareLnurlPay: mockPrepareLnurlPay,
+    executeLnurlPay: mockExecuteLnurlPay,
+    balance: 100000,
+  }),
+  InputType_Tags: {
+    Bolt11Invoice: 'Bolt11Invoice',
+    LightningAddress: 'LightningAddress',
+    LnurlPay: 'LnurlPay',
+  },
+}));
+
+jest.mock('@/lib/context', () => {
+  const React = require('react');
+  return {
+    AppContext: React.createContext({
+      selectedCountry: { name: 'United States', code: 'US', currency: 'USD' },
+    }),
+  };
+});
+
+jest.mock('@/lib/context/bitcoin-prices-context', () => ({
+  useBitcoin: () => ({
+    bitcoinPrices: { BTC: { USD: 50000 } },
+  }),
+}));
+
+jest.mock('@/lib', () => ({
+  convertBitcoinToFiat: () => 2.5,
+  getFiatCurrency: () => 'USD',
+}));
+
+jest.mock('@/components/ui/utils', () => ({
+  showErrorMessage: (...args: unknown[]) => mockShowErrorMessage(...args),
+}));
+
+jest.mock('@/components/slide-to-confirm', () => {
+  const React = require('react');
+  const { Pressable, Text } = require('react-native');
+  return ({ onConfirm, loading }: { onConfirm: () => void; loading?: boolean }) => (
+    <Pressable testID="slide-to-confirm" onPress={onConfirm} disabled={loading}>
+      <Text>{loading ? 'Processing...' : 'Slide to confirm'}</Text>
+    </Pressable>
+  );
+});
+
+jest.mock('react-native-reanimated', () => require('react-native-reanimated/mock'));
+
+afterEach(() => {
+  cleanup();
+  jest.clearAllMocks();
+  mockSearchParams = {};
+});
+
+describe('PaymentDetailsScreen (transaction-details)', () => {
+  describe('Bolt11 Invoice flow', () => {
+    it('shows loading state initially', () => {
+      mockSearchParams = { rawInvoice: 'lnbc1...' };
+      mockParseInput.mockReturnValue(new Promise(() => {})); // never resolves
+
+      setup(<PaymentDetailsScreen />);
+
+      expect(screen.getByText('paymentDetails.loading')).toBeOnTheScreen();
+      expect(screen.getByText('paymentDetails.loadingSubtitle')).toBeOnTheScreen();
+    });
+
+    it('displays invoice details after parsing', async () => {
+      mockSearchParams = { rawInvoice: 'lnbc1...' };
+      mockParseInput.mockResolvedValueOnce({
+        tag: 'Bolt11Invoice',
+        inner: [
+          {
+            amountMsat: 5000000n,
+            invoice: { bolt11: 'lnbc1...' },
+            payeePubkey: '03abc123',
+            description: 'Test payment',
+            expiry: 3600n,
+            timestamp: BigInt(Math.floor(Date.now() / 1000)),
+          },
+        ],
+      });
+      mockPrepareSend.mockResolvedValueOnce({
+        paymentMethod: {
+          inner: { sparkTransferFeeSats: 10n, lightningFeeSats: 5n },
+        },
+      });
+
+      setup(<PaymentDetailsScreen />);
+
+      await waitFor(() => {
+        expect(screen.getByText('paymentDetails.amount')).toBeOnTheScreen();
+      });
+
+      expect(screen.getByText('5000 SAT')).toBeOnTheScreen();
+      expect(screen.getByText('03abc123')).toBeOnTheScreen();
+      expect(screen.getByText('Test payment')).toBeOnTheScreen();
+      expect(screen.getByText('paymentDetails.networkFee')).toBeOnTheScreen();
+    });
+
+    it('shows decode error when invoice parsing fails', async () => {
+      mockSearchParams = { rawInvoice: 'lnbc1...' };
+      mockParseInput.mockResolvedValueOnce({
+        tag: 'Bolt11Invoice',
+        inner: [{ amountMsat: undefined }],
+      });
+
+      setup(<PaymentDetailsScreen />);
+
+      await waitFor(() => {
+        expect(screen.getByText('paymentDetails.errorMessage')).toBeOnTheScreen();
+      });
+    });
+
+    it('shows not enough funds error', async () => {
+      mockSearchParams = { rawInvoice: 'lnbc1...' };
+      mockParseInput.mockResolvedValueOnce({
+        tag: 'Bolt11Invoice',
+        inner: [
+          {
+            amountMsat: 5000000n,
+            invoice: { bolt11: 'lnbc1...' },
+            payeePubkey: '03abc123',
+            expiry: 3600n,
+            timestamp: BigInt(Math.floor(Date.now() / 1000)),
+          },
+        ],
+      });
+      mockPrepareSend.mockRejectedValueOnce(new Error('not enough funds'));
+
+      setup(<PaymentDetailsScreen />);
+
+      await waitFor(() => {
+        expect(screen.getByText('paymentDetails.errorMessage')).toBeOnTheScreen();
+      });
+    });
+
+    it('shows invalidData error on generic parse failure', async () => {
+      mockSearchParams = { rawInvoice: 'lnbc1...' };
+      mockParseInput.mockRejectedValueOnce(new Error('something else'));
+
+      setup(<PaymentDetailsScreen />);
+
+      await waitFor(() => {
+        expect(mockShowErrorMessage).toHaveBeenCalledWith('paymentDetails.errors.invalidData');
+      });
+    });
+
+    it('executes bolt11 payment on confirm', async () => {
+      mockSearchParams = { rawInvoice: 'lnbc1...' };
+      const mockPrepareResponse = {
+        paymentMethod: {
+          inner: { sparkTransferFeeSats: 0n, lightningFeeSats: 0n },
+        },
+      };
+      mockParseInput.mockResolvedValueOnce({
+        tag: 'Bolt11Invoice',
+        inner: [
+          {
+            amountMsat: 1000000n,
+            invoice: { bolt11: 'lnbc1...' },
+            payeePubkey: '03abc123',
+            expiry: 3600n,
+            timestamp: BigInt(Math.floor(Date.now() / 1000)),
+          },
+        ],
+      });
+      mockPrepareSend.mockResolvedValueOnce(mockPrepareResponse);
+      mockExecuteSend.mockResolvedValueOnce({
+        payment: { amount: 1000n },
+      });
+
+      const { user } = setup(<PaymentDetailsScreen />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('slide-to-confirm')).toBeOnTheScreen();
+      });
+
+      await user.press(screen.getByTestId('slide-to-confirm'));
+
+      await waitFor(() => {
+        expect(mockExecuteSend).toHaveBeenCalledWith(mockPrepareResponse);
+      });
+
+      expect(mockPush).toHaveBeenCalledWith({
+        pathname: '/transaction-result/success-screen',
+        params: { transactionType: 'sent', satsAmount: '1000' },
+      });
+    });
+  });
+
+  describe('Lightning Address flow', () => {
+    it('displays LN address as destination', async () => {
+      mockSearchParams = { lightningAddress: 'bob@pay.usegrimm.app', amountSats: '5000' };
+      mockParseInput.mockResolvedValueOnce({
+        tag: 'LightningAddress',
+        inner: [{ address: 'bob@pay.usegrimm.app', payRequest: { callback: 'https://getalby.com/lnurlp/alice' } }],
+      });
+      mockPrepareLnurlPay.mockResolvedValueOnce({
+        amountSats: 5000n,
+        feeSats: 10n,
+      });
+
+      setup(<PaymentDetailsScreen />);
+
+      await waitFor(() => {
+        expect(screen.getByText('bob@pay.usegrimm.app')).toBeOnTheScreen();
+      });
+
+      expect(screen.getByText('5000 SAT')).toBeOnTheScreen();
+    });
+
+    it('handles LnurlPay input type', async () => {
+      mockSearchParams = { lightningAddress: 'lnurl1...', amountSats: '3000' };
+      mockParseInput.mockResolvedValueOnce({
+        tag: 'LnurlPay',
+        inner: [{ callback: 'https://usegrimm.app/lnurlp' }],
+      });
+      mockPrepareLnurlPay.mockResolvedValueOnce({
+        amountSats: 3000n,
+        feeSats: 5n,
+      });
+
+      setup(<PaymentDetailsScreen />);
+
+      await waitFor(() => {
+        expect(screen.getByText('3000 SAT')).toBeOnTheScreen();
+      });
+    });
+
+    it('shows decode error for unsupported parsed type', async () => {
+      mockSearchParams = { lightningAddress: 'bad@pay.usegrimm.app', amountSats: '1000' };
+      mockParseInput.mockResolvedValueOnce({
+        tag: 'BitcoinAddress',
+        inner: [{ address: 'bc1q...' }],
+      });
+
+      setup(<PaymentDetailsScreen />);
+
+      await waitFor(() => {
+        expect(screen.getByText('paymentDetails.errorMessage')).toBeOnTheScreen();
+      });
+    });
+
+    it('shows not enough funds error for LN address', async () => {
+      mockSearchParams = { lightningAddress: 'bob@pay.usegrimm.app', amountSats: '5000' };
+      mockParseInput.mockResolvedValueOnce({
+        tag: 'LightningAddress',
+        inner: [{ address: 'bob@pay.usegrimm.app', payRequest: {} }],
+      });
+      mockPrepareLnurlPay.mockRejectedValueOnce(new Error('not enough funds'));
+
+      setup(<PaymentDetailsScreen />);
+
+      await waitFor(() => {
+        expect(screen.getByText('paymentDetails.errorMessage')).toBeOnTheScreen();
+      });
+    });
+
+    it('shows invalidData error for generic LN address failure', async () => {
+      mockSearchParams = { lightningAddress: 'bob@pay.usegrimm.app', amountSats: '5000' };
+      mockParseInput.mockResolvedValueOnce({
+        tag: 'LightningAddress',
+        inner: [{ address: 'bob@pay.usegrimm.app', payRequest: {} }],
+      });
+      mockPrepareLnurlPay.mockRejectedValueOnce(new Error('generic failure'));
+
+      setup(<PaymentDetailsScreen />);
+
+      await waitFor(() => {
+        expect(mockShowErrorMessage).toHaveBeenCalledWith('paymentDetails.errors.invalidData');
+      });
+    });
+
+    it('executes LNURL payment on confirm', async () => {
+      mockSearchParams = { lightningAddress: 'bob@pay.usegrimm.app', amountSats: '5000' };
+      const mockLnurlPrepareResponse = {
+        amountSats: 5000n,
+        feeSats: 10n,
+      };
+      mockParseInput.mockResolvedValueOnce({
+        tag: 'LightningAddress',
+        inner: [{ address: 'bob@pay.usegrimm.app', payRequest: { callback: 'https://getalby.com' } }],
+      });
+      mockPrepareLnurlPay.mockResolvedValueOnce(mockLnurlPrepareResponse);
+      mockExecuteLnurlPay.mockResolvedValueOnce({ amount: 5000n });
+
+      const { user } = setup(<PaymentDetailsScreen />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('slide-to-confirm')).toBeOnTheScreen();
+      });
+
+      await user.press(screen.getByTestId('slide-to-confirm'));
+
+      await waitFor(() => {
+        expect(mockExecuteLnurlPay).toHaveBeenCalledWith(mockLnurlPrepareResponse);
+      });
+
+      expect(mockPush).toHaveBeenCalledWith({
+        pathname: '/transaction-result/success-screen',
+        params: { transactionType: 'sent', satsAmount: '5000' },
+      });
+    });
+
+    it('does not show expiry timer for LN address', async () => {
+      mockSearchParams = { lightningAddress: 'bob@pay.usegrimm.app', amountSats: '5000' };
+      mockParseInput.mockResolvedValueOnce({
+        tag: 'LightningAddress',
+        inner: [{ address: 'bob@pay.usegrimm.app', payRequest: {} }],
+      });
+      mockPrepareLnurlPay.mockResolvedValueOnce({
+        amountSats: 5000n,
+        feeSats: 0n,
+      });
+
+      setup(<PaymentDetailsScreen />);
+
+      await waitFor(() => {
+        expect(screen.getByText('bob@pay.usegrimm.app')).toBeOnTheScreen();
+      });
+
+      expect(screen.queryByText('paymentDetails.expiresIn')).not.toBeOnTheScreen();
+    });
+  });
+
+  describe('Insufficient balance', () => {
+    it('shows insufficient balance for bolt11 when total exceeds balance', async () => {
+      mockSearchParams = { rawInvoice: 'lnbc1...' };
+      mockParseInput.mockResolvedValueOnce({
+        tag: 'Bolt11Invoice',
+        inner: [
+          {
+            amountMsat: BigInt(200000 * 1000),
+            invoice: { bolt11: 'lnbc1...' },
+            payeePubkey: '03abc123',
+            expiry: 3600n,
+            timestamp: BigInt(Math.floor(Date.now() / 1000)),
+          },
+        ],
+      });
+      mockPrepareSend.mockResolvedValueOnce({
+        paymentMethod: {
+          inner: { sparkTransferFeeSats: 0n, lightningFeeSats: 0n },
+        },
+      });
+
+      setup(<PaymentDetailsScreen />);
+
+      await waitFor(() => {
+        expect(screen.getByText('paymentDetails.errors.notEnoughFunds')).toBeOnTheScreen();
+      });
+    });
+  });
+
+  describe('Invalid payment guard', () => {
+    it('shows error when trying to send without decoded data (bolt11 path)', async () => {
+      mockSearchParams = { rawInvoice: 'lnbc1...' };
+      mockParseInput.mockResolvedValueOnce({
+        tag: 'Bolt11Invoice',
+        inner: [
+          {
+            amountMsat: 1000000n,
+            invoice: { bolt11: 'lnbc1...' },
+            payeePubkey: '03abc',
+            expiry: 3600n,
+            timestamp: BigInt(Math.floor(Date.now() / 1000)),
+          },
+        ],
+      });
+      // prepareSend fails so no savedPrepareResponse
+      mockPrepareSend.mockRejectedValueOnce(new Error('some error'));
+
+      setup(<PaymentDetailsScreen />);
+
+      await waitFor(() => {
+        expect(mockShowErrorMessage).toHaveBeenCalledWith('paymentDetails.errors.invalidData');
+      });
+    });
+  });
+
+  describe('Error screen', () => {
+    it('renders go back button on error screen', async () => {
+      mockSearchParams = { rawInvoice: 'lnbc1...' };
+      mockParseInput.mockResolvedValueOnce({
+        tag: 'Bolt11Invoice',
+        inner: [{ amountMsat: undefined }],
+      });
+
+      const { user } = setup(<PaymentDetailsScreen />);
+
+      await waitFor(() => {
+        expect(screen.getByText('paymentDetails.goBack')).toBeOnTheScreen();
+      });
+
+      await user.press(screen.getByText('paymentDetails.goBack'));
+
+      expect(mockBack).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/send/enter-address.tsx
+++ b/src/app/send/enter-address.tsx
@@ -4,7 +4,6 @@ import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ActivityIndicator, ScrollView, TextInput } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
-import validator from 'validator';
 
 import { HeaderLeft } from '@/components/back-button';
 import { HeaderTitle } from '@/components/header-title';
@@ -38,11 +37,6 @@ export default function LightningPaymentScreen() {
       setAddressError(true);
       return;
     }
-    if (validator.isEmail(invoiceInput.trim())) {
-      showErrorMessage(t('lightningPayment.errors.lightningAddressNotSupported'));
-      setAddressError(true);
-      return;
-    }
 
     try {
       setIsLoading(true);
@@ -63,6 +57,15 @@ export default function LightningPaymentScreen() {
             pathname: '/send/transaction-details',
             params: {
               rawInvoice: parsed.inner[0].invoice.bolt11,
+            },
+          });
+          break;
+        case InputType_Tags.LnurlPay:
+        case InputType_Tags.LightningAddress:
+          router.push({
+            pathname: '/send/enter-amount',
+            params: {
+              lightningAddress: invoiceInput.trim(),
             },
           });
           break;

--- a/src/app/send/enter-address.tsx
+++ b/src/app/send/enter-address.tsx
@@ -65,7 +65,7 @@ export default function LightningPaymentScreen() {
           router.push({
             pathname: '/send/enter-amount',
             params: {
-              lightningAddress: invoiceInput.trim(),
+              paymentInput: invoiceInput.trim(),
             },
           });
           break;

--- a/src/app/send/enter-amount.tsx
+++ b/src/app/send/enter-amount.tsx
@@ -17,13 +17,13 @@ import { useBreez } from '@/lib/context/breez-context';
 import { BitcoinUnit } from '@/types/enum';
 
 type SearchParams = {
-  lightningAddress: string;
+  paymentInput: string;
 };
 
 export default function LightningAddressAmountScreen() {
   const { t } = useTranslation();
   const router = useRouter();
-  const { lightningAddress } = useLocalSearchParams<SearchParams>();
+  const { paymentInput } = useLocalSearchParams<SearchParams>();
   const { bitcoinUnit, selectedCountry } = useContext(AppContext);
   const { bitcoinPrices } = useBitcoin();
   const { balance } = useBreez();
@@ -67,7 +67,7 @@ export default function LightningAddressAmountScreen() {
     router.push({
       pathname: '/send/transaction-details',
       params: {
-        lightningAddress,
+        paymentInput,
         amountSats: satsValue.toString(),
       },
     });
@@ -88,7 +88,7 @@ export default function LightningAddressAmountScreen() {
         <View className="flex-1 px-4 pt-6">
           <View className="mb-4 items-center">
             <Text className="text-base text-gray-500">
-              {t('enterAmount.sendTo')} {lightningAddress}
+              {t('enterAmount.sendTo')} {paymentInput}
             </Text>
           </View>
           <View className="mb-6 items-center">
@@ -117,7 +117,7 @@ export default function LightningAddressAmountScreen() {
           <View className="flex-1" />
           <NumericKeypad amount={amount} setAmount={setAmount} isBtcUnit={isBtcUnit} />
           <View className="mb-4">
-            <Button label={t('common.continue')} onPress={handleContinue} fullWidth variant="secondary" size="lg" disabled={isAmountInvalid} textClassName="text-base text-white" />
+            <Button label={t('enterAmount.continueButton')} onPress={handleContinue} fullWidth variant="secondary" size="lg" disabled={isAmountInvalid} textClassName="text-base text-white" />
           </View>
         </View>
       </SafeAreaView>

--- a/src/app/send/enter-amount.tsx
+++ b/src/app/send/enter-amount.tsx
@@ -1,0 +1,126 @@
+/* eslint-disable react/no-unstable-nested-components */
+/* eslint-disable max-lines-per-function */
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
+import React, { useContext, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+
+import { HeaderLeft } from '@/components/back-button';
+import { HeaderTitle } from '@/components/header-title';
+import { Button, colors, FocusAwareStatusBar, SafeAreaView, Text, View } from '@/components/ui';
+import { NumericKeypad } from '@/components/ui';
+import { convertBitcoinToFiat, convertBtcToSats, getFiatCurrency } from '@/lib';
+import { AppContext } from '@/lib/context';
+import { useBitcoin } from '@/lib/context/bitcoin-prices-context';
+import { useBreez } from '@/lib/context/breez-context';
+import { BitcoinUnit } from '@/types/enum';
+
+type SearchParams = {
+  lightningAddress: string;
+};
+
+export default function LightningAddressAmountScreen() {
+  const { t } = useTranslation();
+  const router = useRouter();
+  const { lightningAddress } = useLocalSearchParams<SearchParams>();
+  const { bitcoinUnit, selectedCountry } = useContext(AppContext);
+  const { bitcoinPrices } = useBitcoin();
+  const { balance } = useBreez();
+
+  const [amount, setAmount] = useState('0');
+  const [fiatAmount, setFiatAmount] = useState('0');
+  const [validationError, setValidationError] = useState('');
+
+  const isBtcUnit = bitcoinUnit === BitcoinUnit.Btc;
+  const selectedFiatCurrency = getFiatCurrency(selectedCountry);
+  const satsAmount = isBtcUnit ? convertBtcToSats(Number(amount)) : Number(amount);
+  const isAmountInvalid = !Number(amount) || satsAmount > balance;
+
+  useEffect(() => {
+    if (!amount || amount === '0' || amount === '.') {
+      setFiatAmount('0');
+      setValidationError('');
+      return;
+    }
+
+    const satsValue = isBtcUnit ? Math.round(parseFloat(amount) * 1e8) : parseInt(amount, 10);
+
+    if (isNaN(satsValue)) {
+      setValidationError(t('enterAmount.invalidAmount'));
+      return;
+    }
+
+    setValidationError('');
+    const fiat = convertBitcoinToFiat(satsValue, BitcoinUnit.Sats, selectedFiatCurrency, bitcoinPrices).toFixed(2);
+    setFiatAmount(fiat);
+  }, [amount, isBtcUnit, bitcoinPrices, selectedFiatCurrency, t]);
+
+  const handleContinue = () => {
+    const satsValue = isBtcUnit ? Math.round(parseFloat(amount) * 1e8) : parseInt(amount, 10);
+
+    if (!satsValue || isNaN(satsValue)) {
+      setValidationError(t('enterAmount.invalidAmount'));
+      return;
+    }
+
+    router.push({
+      pathname: '/send/transaction-details',
+      params: {
+        lightningAddress,
+        amountSats: satsValue.toString(),
+      },
+    });
+  };
+
+  return (
+    <SafeAreaProvider>
+      <SafeAreaView className="flex-1 bg-white">
+        <FocusAwareStatusBar style="dark" />
+        <Stack.Screen
+          options={{
+            headerTitle: () => <HeaderTitle title={t('enterAmount.headerTitle')} />,
+            headerLeft: HeaderLeft,
+            headerTitleAlign: 'center',
+            headerShadowVisible: false,
+          }}
+        />
+        <View className="flex-1 px-4 pt-6">
+          <View className="mb-4 items-center">
+            <Text className="text-base text-gray-500">
+              {t('enterAmount.sendTo')} {lightningAddress}
+            </Text>
+          </View>
+          <View className="mb-6 items-center">
+            <View className="flex-row items-center">
+              <Text className={`text-6xl font-light ${validationError ? 'text-red-400' : 'text-gray-800'}`}>{amount}</Text>
+              <Text className="ml-2 text-2xl font-light text-gray-400">{bitcoinUnit}</Text>
+            </View>
+            {validationError && <Text className="mt-2 text-center text-sm text-red-500">{validationError}</Text>}
+          </View>
+          <View className="mb-6 items-center">
+            <View className="rounded-full bg-primary-600 p-2">
+              <MaterialCommunityIcons name="approximately-equal" size={20} color={colors.white} />
+            </View>
+          </View>
+          <View className="mb-8 items-center">
+            <View className="flex-row items-center">
+              <Text className="mr-2 text-xl font-medium text-gray-800">{fiatAmount}</Text>
+              <Text className="text-xl font-semibold text-gray-600">{selectedFiatCurrency}</Text>
+            </View>
+          </View>
+          {Number(amount) > 0 && satsAmount > balance && (
+            <View>
+              <Text className="text-center text-base font-semibold text-danger-600">{t('enterAmount.insufficientBalance')}</Text>
+            </View>
+          )}
+          <View className="flex-1" />
+          <NumericKeypad amount={amount} setAmount={setAmount} isBtcUnit={isBtcUnit} />
+          <View className="mb-4">
+            <Button label={t('common.continue')} onPress={handleContinue} fullWidth variant="secondary" size="lg" disabled={isAmountInvalid} textClassName="text-base text-white" />
+          </View>
+        </View>
+      </SafeAreaView>
+    </SafeAreaProvider>
+  );
+}

--- a/src/app/send/transaction-details.tsx
+++ b/src/app/send/transaction-details.tsx
@@ -22,14 +22,14 @@ import { BitcoinUnit } from '@/types/enum';
 
 type SearchParams = {
   rawInvoice?: string;
-  lightningAddress?: string;
+  paymentInput?: string;
   amountSats?: string;
 };
 
 export default function PaymentDetailsScreen() {
   const { t } = useTranslation();
   const router = useRouter();
-  const { rawInvoice, lightningAddress, amountSats } = useLocalSearchParams<SearchParams>();
+  const { rawInvoice, paymentInput, amountSats } = useLocalSearchParams<SearchParams>();
 
   const { selectedCountry } = useContext(AppContext);
   const { bitcoinPrices } = useBitcoin();
@@ -49,17 +49,23 @@ export default function PaymentDetailsScreen() {
     return Number(msat / 1000n);
   };
 
-  const isLnAddress = !!lightningAddress && !!amountSats;
+  const isLnAddress = !!paymentInput && !!amountSats;
+  const parsedAmountSats = parseInt(amountSats || '', 10);
   const selectedFiatCurrency = getFiatCurrency(selectedCountry);
-  const amountSat = isLnAddress ? Number(amountSats) : convertMsatToSats(decodedInvoiceData?.amountMsat || 0n);
+  const amountSat = isLnAddress ? (isNaN(parsedAmountSats) ? 0 : parsedAmountSats) : convertMsatToSats(decodedInvoiceData?.amountMsat || 0n);
   const totalAmountSat = Number((feesSat || 0) + amountSat);
   const hasInsufficientBalance = totalAmountSat > balance;
 
   useEffect(() => {
     const prepareLnAddress = async () => {
-      if (!lightningAddress || !amountSats) return;
+      if (!paymentInput || !amountSats) return;
+      if (isNaN(parsedAmountSats) || parsedAmountSats <= 0) {
+        setDecodeError(t('paymentDetails.errors.invalidData'));
+        setIsLoading(false);
+        return;
+      }
       try {
-        const parsed = await parseInput(lightningAddress);
+        const parsed = await parseInput(paymentInput.trim());
         let payRequest;
         if (parsed.tag === InputType_Tags.LightningAddress) {
           payRequest = parsed.inner[0].payRequest;
@@ -69,14 +75,14 @@ export default function PaymentDetailsScreen() {
           setDecodeError(t('paymentDetails.errors.decode'));
           return;
         }
-        const prepareResponse = await prepareLnurlPay(Number(amountSats), payRequest);
+        const prepareResponse = await prepareLnurlPay(parsedAmountSats, payRequest);
         setFeesSat(Number(prepareResponse.feeSats));
         setSavedLnurlPrepareResponse(prepareResponse);
       } catch (error) {
         if ((error as Error).message?.includes('not enough funds')) {
           setDecodeError(t('paymentDetails.errors.notEnoughFunds'));
         } else {
-          showErrorMessage(t('paymentDetails.errors.invalidData'));
+          setDecodeError(t('paymentDetails.errors.invalidData'));
           console.error('Error preparing LN address payment:', (error as Error)?.message);
         }
       } finally {
@@ -118,8 +124,11 @@ export default function PaymentDetailsScreen() {
       prepareLnAddress();
     } else if (rawInvoice) {
       parseInvoice();
+    } else {
+      setDecodeError(t('paymentDetails.errors.invalidData'));
+      setIsLoading(false);
     }
-  }, [parseInput, prepareSend, prepareLnurlPay, rawInvoice, lightningAddress, amountSats, isLnAddress, router, t]);
+  }, [parseInput, prepareSend, prepareLnurlPay, rawInvoice, paymentInput, amountSats, parsedAmountSats, isLnAddress, router, t]);
 
   useEffect(() => {
     if (!decodedInvoiceData?.expiry || !decodedInvoiceData?.timestamp) return;
@@ -153,7 +162,7 @@ export default function PaymentDetailsScreen() {
 
   const getDestinationDisplay = () => {
     if (isLnAddress) {
-      return lightningAddress;
+      return paymentInput;
     }
     if (decodedInvoiceData?.payeePubkey) {
       return decodedInvoiceData?.payeePubkey;
@@ -176,6 +185,8 @@ export default function PaymentDetailsScreen() {
             pathname: '/transaction-result/success-screen',
             params: { transactionType: 'sent', satsAmount: Number(payment.amount).toString() },
           });
+        } else {
+          showErrorMessage(t('paymentDetails.errors.invalidPayment'));
         }
       } else if (savedPrepareResponse) {
         const sendResponse = await executeSend(savedPrepareResponse);

--- a/src/app/send/transaction-details.tsx
+++ b/src/app/send/transaction-details.tsx
@@ -15,23 +15,25 @@ import { Button, colors, FocusAwareStatusBar, SafeAreaView, showErrorMessage, Te
 import { convertBitcoinToFiat, getFiatCurrency } from '@/lib';
 import { AppContext } from '@/lib/context';
 import { useBitcoin } from '@/lib/context/bitcoin-prices-context';
-import type { Bolt11InvoiceDetails, PrepareSendPaymentResponse } from '@/lib/context/breez-context';
+import type { Bolt11InvoiceDetails, PrepareLnurlPayResponse, PrepareSendPaymentResponse } from '@/lib/context/breez-context';
 import { useBreez } from '@/lib/context/breez-context';
 import { InputType_Tags } from '@/lib/context/breez-context';
 import { BitcoinUnit } from '@/types/enum';
 
 type SearchParams = {
-  rawInvoice: string;
+  rawInvoice?: string;
+  lightningAddress?: string;
+  amountSats?: string;
 };
 
 export default function PaymentDetailsScreen() {
   const { t } = useTranslation();
   const router = useRouter();
-  const { rawInvoice } = useLocalSearchParams<SearchParams>();
+  const { rawInvoice, lightningAddress, amountSats } = useLocalSearchParams<SearchParams>();
 
   const { selectedCountry } = useContext(AppContext);
   const { bitcoinPrices } = useBitcoin();
-  const { parseInput, prepareSend, executeSend, balance } = useBreez();
+  const { parseInput, prepareSend, executeSend, prepareLnurlPay, executeLnurlPay, balance } = useBreez();
 
   const [isLoading, setIsLoading] = useState(true);
   const [timeRemaining, setTimeRemaining] = useState('');
@@ -40,51 +42,84 @@ export default function PaymentDetailsScreen() {
   const [decodedInvoiceData, setDecodedInvoiceData] = useState<Bolt11InvoiceDetails>();
   const [paymentIsProcessing, setPaymentIsProcessing] = useState(false);
   const [savedPrepareResponse, setSavedPrepareResponse] = useState<PrepareSendPaymentResponse | null>(null);
+  const [savedLnurlPrepareResponse, setSavedLnurlPrepareResponse] = useState<PrepareLnurlPayResponse | null>(null);
 
   const convertMsatToSats = (msat: bigint | undefined) => {
     if (msat === undefined) return 0;
     return Number(msat / 1000n);
   };
 
+  const isLnAddress = !!lightningAddress && !!amountSats;
   const selectedFiatCurrency = getFiatCurrency(selectedCountry);
-  const amountSat = convertMsatToSats(decodedInvoiceData?.amountMsat || 0n);
+  const amountSat = isLnAddress ? Number(amountSats) : convertMsatToSats(decodedInvoiceData?.amountMsat || 0n);
   const totalAmountSat = Number((feesSat || 0) + amountSat);
   const hasInsufficientBalance = totalAmountSat > balance;
 
   useEffect(() => {
-    if (rawInvoice) {
-      const parseInvoice = async () => {
-        try {
-          const parsed = await parseInput(rawInvoice.trim());
-          if (parsed.tag === InputType_Tags.Bolt11Invoice && parsed.inner[0].amountMsat !== undefined) {
-            setDecodedInvoiceData(parsed.inner[0]);
-            const prepareResponse = await prepareSend(parsed.inner[0].invoice.bolt11);
-            // Extract fee from prepare response
-            const method = prepareResponse.paymentMethod;
-            let totalFees = 0;
-            if (method && 'inner' in method) {
-              const inner = method.inner as any;
-              totalFees = Number(inner.sparkTransferFeeSats || 0n) + Number(inner.lightningFeeSats || 0n);
-            }
-            setFeesSat(totalFees);
-            setSavedPrepareResponse(prepareResponse);
-          } else {
-            setDecodeError(t('paymentDetails.errors.decode'));
-          }
-        } catch (error) {
-          if ((error as Error).message?.includes('not enough funds')) {
-            setDecodeError(t('paymentDetails.errors.notEnoughFunds'));
-          } else {
-            showErrorMessage(t('paymentDetails.errors.invalidData'));
-          }
-          console.error('Error parsing invoice data:', (error as Error)?.message);
-        } finally {
-          setIsLoading(false);
+    const prepareLnAddress = async () => {
+      if (!lightningAddress || !amountSats) return;
+      try {
+        const parsed = await parseInput(lightningAddress);
+        let payRequest;
+        if (parsed.tag === InputType_Tags.LightningAddress) {
+          payRequest = parsed.inner[0].payRequest;
+        } else if (parsed.tag === InputType_Tags.LnurlPay) {
+          payRequest = parsed.inner[0];
+        } else {
+          setDecodeError(t('paymentDetails.errors.decode'));
+          return;
         }
-      };
+        const prepareResponse = await prepareLnurlPay(Number(amountSats), payRequest);
+        setFeesSat(Number(prepareResponse.feeSats));
+        setSavedLnurlPrepareResponse(prepareResponse);
+      } catch (error) {
+        if ((error as Error).message?.includes('not enough funds')) {
+          setDecodeError(t('paymentDetails.errors.notEnoughFunds'));
+        } else {
+          showErrorMessage(t('paymentDetails.errors.invalidData'));
+          console.error('Error preparing LN address payment:', (error as Error)?.message);
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    const parseInvoice = async () => {
+      if (!rawInvoice) return;
+      try {
+        const parsed = await parseInput(rawInvoice.trim());
+        if (parsed.tag === InputType_Tags.Bolt11Invoice && parsed.inner[0].amountMsat !== undefined) {
+          setDecodedInvoiceData(parsed.inner[0]);
+          const prepareResponse = await prepareSend(parsed.inner[0].invoice.bolt11);
+          const method = prepareResponse.paymentMethod;
+          let totalFees = 0;
+          if (method && 'inner' in method) {
+            const inner = method.inner as any;
+            totalFees = Number(inner.sparkTransferFeeSats || 0n) + Number(inner.lightningFeeSats || 0n);
+          }
+          setFeesSat(totalFees);
+          setSavedPrepareResponse(prepareResponse);
+        } else {
+          setDecodeError(t('paymentDetails.errors.decode'));
+        }
+      } catch (error) {
+        if ((error as Error).message?.includes('not enough funds')) {
+          setDecodeError(t('paymentDetails.errors.notEnoughFunds'));
+        } else {
+          showErrorMessage(t('paymentDetails.errors.invalidData'));
+        }
+        console.error('Error parsing invoice data:', (error as Error)?.message);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    if (isLnAddress) {
+      prepareLnAddress();
+    } else if (rawInvoice) {
       parseInvoice();
     }
-  }, [parseInput, prepareSend, rawInvoice, router, t]);
+  }, [parseInput, prepareSend, prepareLnurlPay, rawInvoice, lightningAddress, amountSats, isLnAddress, router, t]);
 
   useEffect(() => {
     if (!decodedInvoiceData?.expiry || !decodedInvoiceData?.timestamp) return;
@@ -117,6 +152,9 @@ export default function PaymentDetailsScreen() {
   }, [decodedInvoiceData, t]);
 
   const getDestinationDisplay = () => {
+    if (isLnAddress) {
+      return lightningAddress;
+    }
     if (decodedInvoiceData?.payeePubkey) {
       return decodedInvoiceData?.payeePubkey;
     }
@@ -124,14 +162,22 @@ export default function PaymentDetailsScreen() {
   };
 
   const handleSendPayment = async () => {
-    if (!decodedInvoiceData) {
+    if (!isLnAddress && !decodedInvoiceData) {
       showErrorMessage(t('paymentDetails.errors.invalidPayment'));
       return;
     }
 
-    if (savedPrepareResponse) {
-      setPaymentIsProcessing(true);
-      try {
+    setPaymentIsProcessing(true);
+    try {
+      if (isLnAddress && savedLnurlPrepareResponse) {
+        const payment = await executeLnurlPay(savedLnurlPrepareResponse);
+        if (payment) {
+          router.push({
+            pathname: '/transaction-result/success-screen',
+            params: { transactionType: 'sent', satsAmount: Number(payment.amount).toString() },
+          });
+        }
+      } else if (savedPrepareResponse) {
         const sendResponse = await executeSend(savedPrepareResponse);
         const payment = sendResponse.payment;
         if (payment) {
@@ -140,9 +186,9 @@ export default function PaymentDetailsScreen() {
             params: { transactionType: 'sent', satsAmount: Number(payment.amount).toString() },
           });
         }
-      } finally {
-        setPaymentIsProcessing(false);
       }
+    } finally {
+      setPaymentIsProcessing(false);
     }
   };
 
@@ -255,7 +301,7 @@ export default function PaymentDetailsScreen() {
             </View>
           </ScrollView>
           <View className="border-t border-gray-100 bg-white px-4">
-            {timeRemaining && (
+            {!isLnAddress && timeRemaining && (
               <View className="my-4 items-center">
                 <Text className="text-sm text-gray-600">
                   {timeRemaining === t('paymentDetails.expired') ? (

--- a/src/lib/context/breez-context.tsx
+++ b/src/lib/context/breez-context.tsx
@@ -6,13 +6,28 @@ import type {
   GetInfoResponse,
   InputType,
   ListPaymentsRequest,
+  LnurlPayRequestDetails,
   Payment,
+  PrepareLnurlPayResponse,
   PrepareSendPaymentResponse,
   ReceivePaymentResponse,
   SdkEvent,
   SendPaymentResponse,
 } from '@breeztech/breez-sdk-spark-react-native';
-import { connect, defaultConfig, Network, PaymentType, PrepareSendPaymentRequest, ReceivePaymentMethod, SdkEvent_Tags, Seed, SendPaymentOptions, SendPaymentRequest } from '@breeztech/breez-sdk-spark-react-native';
+import {
+  connect,
+  defaultConfig,
+  LnurlPayRequest,
+  Network,
+  PaymentType,
+  PrepareLnurlPayRequest,
+  PrepareSendPaymentRequest,
+  ReceivePaymentMethod,
+  SdkEvent_Tags,
+  Seed,
+  SendPaymentOptions,
+  SendPaymentRequest,
+} from '@breeztech/breez-sdk-spark-react-native';
 import { Env } from '@env';
 import { useAsyncStorage } from '@react-native-async-storage/async-storage';
 import * as FileSystem from 'expo-file-system';
@@ -56,6 +71,8 @@ interface BreezContextType {
   parseInput: (input: string) => Promise<InputType>;
   prepareSend: (paymentRequest: string, amountSats?: number) => Promise<PrepareSendPaymentResponse>;
   executeSend: (prepareResponse: PrepareSendPaymentResponse) => Promise<SendPaymentResponse>;
+  prepareLnurlPay: (amountSats: number, payRequest: LnurlPayRequestDetails) => Promise<PrepareLnurlPayResponse>;
+  executeLnurlPay: (prepareResponse: PrepareLnurlPayResponse) => Promise<Payment | undefined>;
 }
 
 const defaultContext: BreezContextType = {
@@ -98,6 +115,12 @@ const defaultContext: BreezContextType = {
     throw new Error('Breez not initialized');
   },
   executeSend: async () => {
+    throw new Error('Breez not initialized');
+  },
+  prepareLnurlPay: async () => {
+    throw new Error('Breez not initialized');
+  },
+  executeLnurlPay: async () => {
     throw new Error('Breez not initialized');
   },
 };
@@ -331,6 +354,26 @@ export const BreezProvider: React.FC<BreezProviderProps> = ({ children }) => {
     );
   }, []);
 
+  const prepareLnurlPay = useCallback(async (amountSats: number, payRequest: LnurlPayRequestDetails): Promise<PrepareLnurlPayResponse> => {
+    if (!sdkRef.current) throw new Error('Breez SDK not initialized');
+    return sdkRef.current.prepareLnurlPay(
+      PrepareLnurlPayRequest.new({
+        amountSats: BigInt(amountSats),
+        payRequest,
+      }),
+    );
+  }, []);
+
+  const executeLnurlPay = useCallback(async (prepareResponse: PrepareLnurlPayResponse): Promise<Payment | undefined> => {
+    if (!sdkRef.current) throw new Error('Breez SDK not initialized');
+    const response = await sdkRef.current.lnurlPay(
+      LnurlPayRequest.new({
+        prepareResponse,
+      }),
+    );
+    return response.payment;
+  }, []);
+
   const initializeBreez = useCallback(async (): Promise<void> => {
     if (isInitializingRef.current || isBreezInitialized) return;
 
@@ -500,6 +543,8 @@ export const BreezProvider: React.FC<BreezProviderProps> = ({ children }) => {
     parseInput,
     prepareSend,
     executeSend,
+    prepareLnurlPay,
+    executeLnurlPay,
   };
 
   return <BreezContext.Provider value={contextValue}>{children}</BreezContext.Provider>;
@@ -514,5 +559,5 @@ export const useBreez = (): BreezContextType => {
 };
 
 // Re-export types and enums that consumers need
-export type { Bolt11InvoiceDetails, GetInfoResponse, InputType, Payment, PrepareSendPaymentResponse, ReceivePaymentResponse, SendPaymentResponse };
+export type { Bolt11InvoiceDetails, GetInfoResponse, InputType, LnurlPayRequestDetails, Payment, PrepareLnurlPayResponse, PrepareSendPaymentResponse, ReceivePaymentResponse, SendPaymentResponse };
 export { InputType_Tags, PaymentType, SendPaymentMethod_Tags } from '@breeztech/breez-sdk-spark-react-native';

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -87,8 +87,11 @@
       "min": "The minimum amount is {{value}} SATS"
     },
     "headerTitle": "Enter amount",
+    "insufficientBalance": "Your balance is insufficient",
+    "invalidAmount": "Please enter a valid amount",
     "notePlaceholder": "Add a note here...",
-    "satsLabel": "SATS"
+    "satsLabel": "SATS",
+    "sendTo": "Send to"
   },
   "help": {
     "closed": "Closed",
@@ -136,7 +139,7 @@
       "zeroAmountNotSupported": "Sorry, we do not support zero-amount Lightning payments"
     },
     "payButton": "Continue",
-    "placeholder": "Bitcoin Lightning Invoice",
+    "placeholder": "Lightning Invoice or Address",
     "processing": "Processing...",
     "title": "Lightning Payment"
   },

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -87,8 +87,11 @@
       "min": "Le montant minimum est de {{value}} SATS"
     },
     "headerTitle": "Entrer le montant",
+    "insufficientBalance": "Votre solde est insuffisant",
+    "invalidAmount": "Veuillez entrer un montant valide",
     "notePlaceholder": "Ajoutez une note ici...",
-    "satsLabel": "SATS"
+    "satsLabel": "SATS",
+    "sendTo": "Envoyer à"
   },
   "help": {
     "closed": "Fermé",
@@ -136,7 +139,7 @@
       "zeroAmountNotSupported": "Désolé, nous ne prenons pas en charge les paiements Lightning sans montant"
     },
     "payButton": "Continuer",
-    "placeholder": "Facture Bitcoin Lightning",
+    "placeholder": "Facture ou adresse Lightning",
     "processing": "Traitement...",
     "title": "Paiement Lightning"
   },


### PR DESCRIPTION
## What does this do?

Adds support for **Lightning Address** and **LNURL-Pay** in the send flow. Users can now send sats to a Lightning Address (e.g. `alice@getalby.com`) or LNURL, in addition to Bolt11 invoices.

Key changes:
- **New screen** `enter-amount.tsx`: numeric keypad to enter sats/BTC amount with real-time fiat conversion and balance validation
- **Updated `enter-address.tsx`**: recognizes `LnurlPay` and `LightningAddress` input types and routes to the new amount screen
- **Updated `transaction-details.tsx`**: handles the full LNURL-Pay flow (prepare → confirm → execute) alongside existing Bolt11 logic
- **Updated `breez-context.tsx`**: exposes `prepareLnurlPay()` and `executeLnurlPay()` from Breez SDK
- **Updated translations** (EN/FR): new keys for the amount screen, updated placeholder text
- **Removed** `validator` dependency (email validation replaced by Breez SDK input parsing)
- **Added** `AUDIT.md`: open-source security audit document (score 5/10) with remediation plan

## Why did you do this?

Lightning Addresses and LNURL are widely adopted standards for user-friendly Bitcoin payments. Previously, the app only supported raw Bolt11 invoices and explicitly blocked email-like inputs. This change lets users pay anyone with a Lightning Address, which is a critical feature for a self-custodial wallet.

Removing the `validator` dependency reduces the bundle size and eliminates a redundant check — the Breez SDK's `parseInput` already handles input type detection.

## Who/what does this impact?

- **Send flow**: all three screens (`enter-address` → `enter-amount` → `transaction-details`) are affected
- **Breez context consumers**: two new methods available (`prepareLnurlPay`, `executeLnurlPay`)
- **Dependencies**: `validator` and `@types/validator` removed from `package.json`

## How did you test this?

- Added **3 new test suites** with comprehensive coverage:
  - `enter-address.test.tsx` (8 tests): empty input, Bolt11, Lightning Address, LnurlPay, Bitcoin address, unsupported input, error handling
  - `enter-amount.test.tsx` (10 tests): rendering, keypad interaction, navigation, balance validation, fiat conversion
  - `transaction-details.test.tsx` (14 tests): Bolt11 flow, Lightning Address flow, LNURL-Pay flow, insufficient balance, error states, payment execution
