### PR TITLE
218 m006 ecran parametres notifications

### DIFF
--- a/src/app/settings/notifications.tsx
+++ b/src/app/settings/notifications.tsx
@@ -2,15 +2,15 @@
 import Ionicons from '@expo/vector-icons/Ionicons';
 import * as Notifications from 'expo-notifications';
 import { Stack, useFocusEffect } from 'expo-router';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Alert, Linking, Platform } from 'react-native';
+import { Alert, Linking, Platform, Pressable } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import { HeaderLeft } from '@/components/back-button';
 import { HeaderTitle } from '@/components/header-title';
 import { colors, SafeAreaView, ScrollView, Switch, Text, View } from '@/components/ui';
-import { registerDeviceWithNotificationService } from '@/lib/notifications/register-device';
+import { useNotifications } from '@/lib/context/notification-context';
 import { useStackScreenOptions } from '@/lib/stack-screen-options';
 
 function openDeviceNotificationSettings(): void {
@@ -27,45 +27,51 @@ function showOpenSettingsAlert(t: (key: string) => string, titleKey: string, mes
     { text: t('notificationSettings.openSettings'), onPress: openDeviceNotificationSettings },
   ]);
 }
-
-async function handleNotificationToggle(value: boolean, t: (key: string) => string, setIsEnabled: (enabled: boolean) => void): Promise<void> {
-  if (value) {
-    const { status } = await Notifications.requestPermissionsAsync();
-
-    if (status === 'granted') {
-      setIsEnabled(true);
-      await registerDeviceWithNotificationService({ requestPermission: true });
-      return;
-    }
-
-    if (status === 'denied') {
-      showOpenSettingsAlert(t, 'notificationSettings.permissionDeniedTitle', 'notificationSettings.permissionDeniedMessage');
-      setIsEnabled(false);
-    }
-
-    return;
-  }
-
-  showOpenSettingsAlert(t, 'notificationSettings.disableTitle', 'notificationSettings.disableMessage');
-}
-
+// eslint-disable-next-line max-lines-per-function
 export default function NotificationSettingsScreen() {
   const { t } = useTranslation();
   const stackScreenOptions = useStackScreenOptions();
-  const [isEnabled, setIsEnabled] = useState(false);
+  const { isRegistered, isRegistering, registrationError, permissionStatus, registerDevice, refreshPermissionStatus } = useNotifications();
 
-  const refreshPermissionStatus = useCallback(async () => {
-    const { status } = await Notifications.getPermissionsAsync();
-    setIsEnabled(status === 'granted');
-  }, []);
+  const isPermissionGranted = permissionStatus === 'granted';
+  const isFullyEnabled = isPermissionGranted && isRegistered;
+
+  // Le switch reflète l'état « pleinement opérationnel »
+  const switchValue = isFullyEnabled;
+
+  // Sous-titre dynamique
+  const statusLabel = isRegistering
+    ? t('notificationSettings.registering')
+    : isFullyEnabled
+      ? t('notificationSettings.enabled')
+      : isPermissionGranted && !isRegistered
+        ? t('notificationSettings.notRegistered')
+        : t('notificationSettings.disabled');
+
+  const handleToggle = async (value: boolean) => {
+    if (value) {
+      const { status } = await Notifications.requestPermissionsAsync();
+      await refreshPermissionStatus();
+
+      if (status === 'granted') {
+        try {
+          await registerDevice();
+        } catch {
+          // registrationError géré par le contexte
+        }
+      } else if (status === 'denied') {
+        showOpenSettingsAlert(t, 'notificationSettings.permissionDeniedTitle', 'notificationSettings.permissionDeniedMessage');
+      }
+    } else {
+      showOpenSettingsAlert(t, 'notificationSettings.disableTitle', 'notificationSettings.disableMessage');
+    }
+  };
 
   useFocusEffect(
     useCallback(() => {
       refreshPermissionStatus();
     }, [refreshPermissionStatus]),
   );
-
-  const onToggle = useCallback((value: boolean) => handleNotificationToggle(value, t, setIsEnabled), [t]);
 
   return (
     <SafeAreaProvider>
@@ -90,13 +96,21 @@ export default function NotificationSettingsScreen() {
                   </View>
                   <View className="flex-1">
                     <Text className="text-sm font-semibold text-gray-900 dark:text-charcoal-100">{t('notificationSettings.pushNotifications')}</Text>
-                    <Text className="mt-1 text-sm text-gray-500 dark:text-charcoal-400">{isEnabled ? t('notificationSettings.enabled') : t('notificationSettings.disabled')}</Text>
+                    <Text className="mt-1 text-sm text-gray-500 dark:text-charcoal-400">{statusLabel}</Text>
                   </View>
                 </View>
-                <Switch.Root checked={isEnabled} onChange={onToggle} accessibilityLabel="switch" className="pb-2">
-                  <Switch.Icon checked={isEnabled} />
+                <Switch.Root disabled={isRegistering} checked={switchValue} onChange={handleToggle} accessibilityLabel="switch" className="pb-2">
+                  <Switch.Icon checked={switchValue} />
                 </Switch.Root>
               </View>
+              {registrationError && isPermissionGranted && (
+                <View className="mt-3 rounded-xl bg-red-50 p-4 dark:bg-red-950">
+                  <Text className="text-sm text-red-800 dark:text-red-200">{t('notificationSettings.registrationError')}</Text>
+                  <Pressable onPress={() => registerDevice()} className="mt-2">
+                    <Text className="text-sm font-semibold text-red-700">{t('notificationSettings.registrationRetry')}</Text>
+                  </Pressable>
+                </View>
+              )}
             </View>
 
             <View className="mt-4 rounded-xl bg-blue-50 p-4 dark:bg-charcoal-900">

--- a/src/app/settings/notifications.tsx
+++ b/src/app/settings/notifications.tsx
@@ -54,8 +54,8 @@ export default function NotificationSettingsScreen() {
       if (status === 'granted') {
         try {
           await registerDevice();
-        } catch {
-          // registrationError géré par le contexte
+        } catch (error) {
+          console.error('Failed to register device for notifications:', error);
         }
       } else if (status === 'denied') {
         showOpenSettingsAlert(t, 'notificationSettings.permissionDeniedTitle', 'notificationSettings.permissionDeniedMessage');

--- a/src/app/settings/notifications.tsx
+++ b/src/app/settings/notifications.tsx
@@ -36,10 +36,8 @@ export default function NotificationSettingsScreen() {
   const isPermissionGranted = permissionStatus === 'granted';
   const isFullyEnabled = isPermissionGranted && isRegistered;
 
-  // Le switch reflète l'état « pleinement opérationnel »
   const switchValue = isFullyEnabled;
 
-  // Sous-titre dynamique
   const statusLabel = isRegistering
     ? t('notificationSettings.registering')
     : isFullyEnabled

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -336,10 +336,15 @@
     "enabled": "Enabled",
     "header": "Notifications",
     "info": "You will receive notifications for important transactions and security updates",
+    "notRegistered": "Permission granted — registration pending",
     "openSettings": "Open Settings",
+    "partiallyEnabled": "Notifications enabled on device, but server registration failed",
     "permissionDeniedMessage": "To enable notifications, please allow access in your device settings",
     "permissionDeniedTitle": "Permission Denied",
-    "pushNotifications": "Push Notifications"
+    "pushNotifications": "Push Notifications",
+    "registering": "Registering device…",
+    "registrationError": "Could not register for push notifications. Check your connection and try again.",
+    "registrationRetry": "Try again"
   },
   "onboarding": {
     "agreementText": "By Continuing, You agree to the",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -336,10 +336,15 @@
     "enabled": "Activées",
     "header": "Notifications",
     "info": "Vous recevrez des notifications pour les transactions importantes et les mises à jour de sécurité",
+    "notRegistered": "Permission accordée — inscription en attente",
     "openSettings": "Ouvrir paramètres",
+    "partiallyEnabled": "Notifications activées sur l’appareil, mais l’inscription au serveur a échoué",
     "permissionDeniedMessage": "Pour activer les notifications, veuillez autoriser l'accès dans les paramètres de votre appareil",
     "permissionDeniedTitle": "Permission refusée",
-    "pushNotifications": "Notifications Push"
+    "pushNotifications": "Notifications Push",
+    "registering": "Enregistrement de l'appareil…",
+    "registrationError": "Impossible de s’inscrire aux notifications push. Vérifiez votre connexion et réessayez.",
+    "registrationRetry": "Réessayer"
   },
   "onboarding": {
     "agreementText": "En continuant, vous acceptez les",


### PR DESCRIPTION
## What does this do?

Refactors the notification settings screen to use `useNotifications()` from the context provider (M005). The toggle switch now reflects the true end-to-end state — OS permission granted **and** device registered server-side. Adds a registration error banner with a retry button, a dynamic subtitle, and a loading state during registration.

## Why did you do this?

Previously the switch only checked OS permission, so it could show "Enabled" while the device was never actually registered with the push notification server. This gives users an accurate picture of whether push notifications are fully operational, and a way to recover when registration fails.

## Who/what does this impact?

- `src/app/settings/notifications.tsx` — main change
- `src/translations/en.json` and `fr.json` — new keys under `notificationSettings` (`registering`, `registrationError`, `registrationRetry`, `notRegistered`, `partiallyEnabled`)
- Depends on M004/M005 being merged (`NotificationProvider`, `registerDevice`)

## How did you test this?

- Toggle ON first time: OS prompt → POST `/devices` → switch shows "Enabled"
- Toggle ON with permission already granted: skips prompt, calls `registerDevice` directly
- Airplane mode: error banner appears with retry, clears after reconnecting and retrying
- Permission denied: alert shown, switch stays OFF
- Returned from OS settings after revoking permission: `useFocusEffect` resyncs the switch to OFF
- Toggle OFF: OS settings alert shown, no API call made
- Verified EN and FR strings display correctly
- Rapid double-tap on switch: second tap blocked while `isRegistering` is true