### PR TITLE
219 m007 rafraîchissement token et synchronisation

### DIFF
--- a/src/lib/context/notification-context.tsx
+++ b/src/lib/context/notification-context.tsx
@@ -2,10 +2,13 @@ import { Env } from '@env';
 import * as Notifications from 'expo-notifications';
 import type { PropsWithChildren } from 'react';
 import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
+import { AppState } from 'react-native';
 
 import { getStoredDeviceId } from '@/lib/notifications/device-storage';
 import { registerDeviceWithNotificationService } from '@/lib/notifications/register-device';
 
+import { syncDeviceOnForeground } from '../notifications/device-sync';
+import { logSyncFailed } from '../notifications/logger';
 import { useAppContext } from './app-context-provider';
 
 export type NotificationContextType = {
@@ -80,6 +83,26 @@ export const NotificationProvider = ({ children }: PropsWithChildren<{}>) => {
       isMounted = false;
     };
   }, [hasSeedPhrase, isDataLoaded, refreshPermissionStatus, registerDevice]);
+
+  // Dans notification-context.tsx (M005)
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', (nextState) => {
+      if (nextState !== 'active') return;
+      if (!hasSeedPhrase || !isDataLoaded || !Env.NOTIFICATION_API_URL) return;
+
+      syncDeviceOnForeground()
+        .then(async () => {
+          const id = await getStoredDeviceId();
+          setDeviceId(id);
+          setIsRegistered(Boolean(id));
+        })
+        .catch((err) => {
+          logSyncFailed(err.message);
+        });
+    });
+
+    return () => subscription.remove();
+  }, [hasSeedPhrase, isDataLoaded]);
 
   return (
     <NotificationContext.Provider

--- a/src/lib/context/notification-context.tsx
+++ b/src/lib/context/notification-context.tsx
@@ -84,7 +84,6 @@ export const NotificationProvider = ({ children }: PropsWithChildren<{}>) => {
     };
   }, [hasSeedPhrase, isDataLoaded, refreshPermissionStatus, registerDevice]);
 
-  // Dans notification-context.tsx (M005)
   useEffect(() => {
     const subscription = AppState.addEventListener('change', (nextState) => {
       if (nextState !== 'active') return;

--- a/src/lib/notifications/device-sync.ts
+++ b/src/lib/notifications/device-sync.ts
@@ -1,0 +1,72 @@
+import axios from 'axios';
+import * as Application from 'expo-application';
+import Constants from 'expo-constants';
+import * as Localization from 'expo-localization';
+import * as Notifications from 'expo-notifications';
+import * as SecureStore from 'expo-secure-store';
+
+import { updateDevice } from '@/api/notifications';
+
+import { logSyncDebounced, logSyncDevice404, logSyncMetadataOnly, logSyncTokenChanged } from './logger';
+import { getStoredDeviceId, registerDeviceWithNotificationService } from './register-device';
+
+const TOKEN_KEY = 'notification_push_token';
+const LAST_SYNC_KEY = 'notification_last_sync';
+const DEVICE_ID_KEY = 'notification_device_id';
+export const SYNC_DEBOUNCE_MS = 60_000;
+
+function buildMetadataPayload(): { language: string; timezone: string; appVersion: string; expoPushToken?: string } {
+  return {
+    language: Localization.getLocales()[0]?.languageCode ?? 'en',
+    timezone: Localization.getCalendars()[0]?.timeZone ?? 'UTC',
+    appVersion: Application.nativeApplicationVersion ?? 'unknown',
+  };
+}
+
+export async function syncDeviceOnForeground(): Promise<void> {
+  const lastSync = await SecureStore.getItemAsync(LAST_SYNC_KEY);
+  if (lastSync && Date.now() - parseInt(lastSync, 10) < SYNC_DEBOUNCE_MS) {
+    logSyncDebounced();
+    return;
+  }
+
+  const deviceId = await getStoredDeviceId();
+  if (!deviceId) {
+    await registerDeviceWithNotificationService();
+    return;
+  }
+
+  const { status } = await Notifications.getPermissionsAsync();
+  if (status !== 'granted') {
+    return;
+  }
+
+  const projectId = Constants.expoConfig?.extra?.eas?.projectId ?? Constants.easConfig?.projectId;
+
+  const tokenData = await Notifications.getExpoPushTokenAsync({ projectId });
+  const currentToken = tokenData.data;
+  const cachedToken = await SecureStore.getItemAsync(TOKEN_KEY);
+
+  const payload = buildMetadataPayload();
+  if (currentToken !== cachedToken) {
+    logSyncTokenChanged();
+    payload.expoPushToken = currentToken;
+  }
+
+  try {
+    await updateDevice(deviceId, payload);
+    await SecureStore.setItemAsync(TOKEN_KEY, currentToken);
+    await SecureStore.setItemAsync(LAST_SYNC_KEY, Date.now().toString());
+    logSyncMetadataOnly();
+  } catch (err) {
+    if (axios.isAxiosError(err) && err.response?.status === 404) {
+      logSyncDevice404();
+      await SecureStore.deleteItemAsync(DEVICE_ID_KEY);
+      await SecureStore.deleteItemAsync(TOKEN_KEY);
+      await SecureStore.deleteItemAsync(LAST_SYNC_KEY);
+      await registerDeviceWithNotificationService();
+      return;
+    }
+    throw err;
+  }
+}

--- a/src/lib/notifications/logger.ts
+++ b/src/lib/notifications/logger.ts
@@ -71,3 +71,22 @@ export function logRegistrationSuccess(result: { action: 'created' | 'updated' |
 export function logRegistrationFailed(message: string): void {
   log('Device registration failed', { error: message });
 }
+export function logSyncDebounced(): void {
+  log('Foreground sync skipped (debounce)');
+}
+
+export function logSyncTokenChanged(): void {
+  log('Token changed, PATCH with new expoPushToken');
+}
+
+export function logSyncMetadataOnly(): void {
+  log('Foreground sync completed (metadata only)');
+}
+
+export function logSyncDevice404(): void {
+  log('Device 404, clearing local state and re-registering');
+}
+
+export function logSyncFailed(message: string): void {
+  log('Foreground sync failed', { error: message });
+}

--- a/src/lib/notifications/notification-api-client.ts
+++ b/src/lib/notifications/notification-api-client.ts
@@ -1,5 +1,5 @@
-import { assertNotificationServiceConfigured, notificationClient } from './client';
-import type { DeviceResponse } from './types';
+import type { DeviceResponse } from '@/api';
+import { notificationClient } from '@/api/notifications/client';
 
 export type UpdateDevicePayload = {
   expoPushToken?: string;
@@ -9,7 +9,6 @@ export type UpdateDevicePayload = {
 };
 
 export async function updateDevice(deviceId: string, payload: UpdateDevicePayload): Promise<DeviceResponse> {
-  assertNotificationServiceConfigured();
   const { data } = await notificationClient.patch<DeviceResponse>(`/devices/${deviceId}`, payload);
   return data;
 }

--- a/src/lib/notifications/register-device.ts
+++ b/src/lib/notifications/register-device.ts
@@ -254,3 +254,5 @@ export async function registerDeviceWithNotificationService(options: RegisterDev
     throw error;
   }
 }
+
+export { getStoredDeviceId };


### PR DESCRIPTION
## What does this do?

Implements continuous device registration sync via an `AppState` foreground listener in `NotificationProvider`. Every time the app comes back to the foreground, `syncDeviceOnForeground()` fires a `PATCH /devices/:id` with current metadata (language, timezone, app version) and the Expo push token if it has changed. Includes a 60-second debounce to prevent hammering the API on rapid app switches. On a 404 response, local state is cleared and the device re-registers via POST.

## Why did you do this?

The initial registration (M004/M005) only runs once. Without continuous sync, the server can end up with a stale push token after a reinstall, token rotation, or OS permission change — causing silent notification delivery failures. The `lastSeenAt` field updated on every PATCH also feeds into audience targeting (ticket 011), so devices that are actively used get prioritized.

## Who/what does this impact?

- `src/lib/notifications/device-sync.ts` — new module, core sync logic
- `src/lib/context/notification-context.tsx` — AppState listener added, state updated post-sync
- `src/lib/notifications/logger.ts` — new sync-specific log functions added
- Depends on M004/M005 being merged
- Coordinates with M008: sync runs before push handler on foreground

## How did you test this?

- Enabled notifications and registered device via settings screen
- Backgrounded and foregrounded the app — confirmed `PATCH /devices/:id` fires and `lastSeenAt` updates in DB
- Rapid app switching — confirmed debounce limits to one PATCH per 60 seconds
- Verified all log lines appear in terminal (`metadata only`, `debounce skipped`, etc.)
- Confirmed no PATCH fires when permission is not granted
- Confirmed no PATCH fires when `NOTIFICATION_API_URL` is not set