### PR TITLE
221 m009 navigation deep link depuis les notifications

### DIFF
--- a/src/lib/context/notification-context.tsx
+++ b/src/lib/context/notification-context.tsx
@@ -8,8 +8,9 @@ import { getStoredDeviceId } from '@/lib/notifications/device-storage';
 import { registerDeviceWithNotificationService } from '@/lib/notifications/register-device';
 
 import { syncDeviceOnForeground } from '../notifications/device-sync';
+import { handleNotificationNavigation } from '../notifications/handle-notification-navigation';
 import { logSyncFailed } from '../notifications/logger';
-import { configureNotificationChannels, configureNotificationHandler, handleNotificationTap, registerPushListeners } from '../notifications/push-handlers';
+import { configureNotificationChannels, configureNotificationHandler, registerPushListeners } from '../notifications/push-handlers';
 import { useAppContext } from './app-context-provider';
 
 export type NotificationContextType = {
@@ -120,13 +121,13 @@ export const NotificationProvider = ({ children }: PropsWithChildren<{}>) => {
         }
       },
       (response) => {
-        handleNotificationTap(response); // stub → M009
+        handleNotificationNavigation(response);
       },
       { manageBadge: true },
     );
 
     Notifications.getLastNotificationResponseAsync().then((response) => {
-      if (response) handleNotificationTap(response);
+      if (response) handleNotificationNavigation(response);
     });
 
     return cleanup;

--- a/src/lib/context/notification-context.tsx
+++ b/src/lib/context/notification-context.tsx
@@ -47,6 +47,9 @@ export const NotificationProvider = ({ children }: PropsWithChildren<{}>) => {
       if (outcome.status === 'success') {
         setDeviceId(outcome.result.deviceId);
         setIsRegistered(true);
+        if (__DEV__) {
+          console.log('[notifications] Expo push token:', outcome.result.expoPushToken);
+        }
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);

--- a/src/lib/notifications/handle-notification-navigation.ts
+++ b/src/lib/notifications/handle-notification-navigation.ts
@@ -1,0 +1,46 @@
+import * as Linking from 'expo-linking';
+import type { NotificationResponse } from 'expo-notifications';
+import { router } from 'expo-router';
+
+import { ALLOWED_SCREENS, type AllowedScreen, parseNotificationData } from './notification-data.schema';
+
+export function handleNotificationNavigation(response: NotificationResponse): void {
+  const rawData = response.notification.request.content.data;
+  const data = parseNotificationData(rawData);
+
+  if (!data) {
+    router.push('/(app)');
+    return;
+  }
+
+  if (data.url) {
+    Linking.openURL(data.url).catch(() => {
+      router.push('/(app)');
+    });
+    return;
+  }
+
+  if (!data.screen || !isAllowedScreen(data.screen)) {
+    console.warn('[notifications] Écran inconnu:', data.screen);
+    router.push('/(app)');
+    return;
+  }
+
+  navigateToScreen(data.screen, data.params ?? {});
+}
+
+function isAllowedScreen(screen: string): screen is AllowedScreen {
+  return (ALLOWED_SCREENS as readonly string[]).includes(screen);
+}
+
+function navigateToScreen(screen: AllowedScreen, params: Record<string, string>): void {
+  if (screen === '(app)') {
+    router.push('/(app)');
+    return;
+  }
+
+  router.push({
+    pathname: `/${screen}` as `/${AllowedScreen}`,
+    params,
+  });
+}

--- a/src/lib/notifications/notification-data.schema.ts
+++ b/src/lib/notifications/notification-data.schema.ts
@@ -1,0 +1,30 @@
+export interface NotificationData {
+  screen?: string;
+  params?: Record<string, string>;
+  url?: string;
+  campaignId?: string;
+}
+
+export const ALLOWED_SCREENS = ['settings', 'transaction-details/ln', 'transaction-details/onchain', '(app)'] as const;
+
+export type AllowedScreen = (typeof ALLOWED_SCREENS)[number];
+
+export function parseNotificationData(raw: unknown): NotificationData | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const data = raw as Record<string, unknown>;
+  return {
+    screen: typeof data.screen === 'string' ? data.screen : undefined,
+    params: sanitizeParams(data.params),
+    url: typeof data.url === 'string' ? data.url : undefined,
+    campaignId: typeof data.campaignId === 'string' ? data.campaignId : undefined,
+  };
+}
+
+function sanitizeParams(params: unknown): Record<string, string> | undefined {
+  if (!params || typeof params !== 'object') return undefined;
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(params as Record<string, unknown>)) {
+    if (typeof value === 'string') result[key] = value;
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
+}


### PR DESCRIPTION
## What does this do?

Implements deep link navigation from push notification taps. Creates two new modules: `notification-data.schema.ts` defines the `NotificationData` interface (`screen`, `params`, `url`, `campaignId`) and a `parseNotificationData` function that safely extracts typed data from raw notification payloads, with `sanitizeParams` stripping non-string values. `handle-notification-navigation.ts` consumes the parsed data and routes to the correct screen via `expo-router`, validating against a static `ALLOWED_SCREENS` whitelist. External URLs are opened via `Linking.openURL`. Wires `handleNotificationNavigation` into `NotificationProvider` replacing the M008 stub, covering both live taps and cold start via `getLastNotificationResponseAsync`.

## Why did you do this?

Without this, tapping a push notification opened the app but landed on whatever screen was last open. Users receiving a payment notification should land directly on the transaction detail screen. The allowlist prevents the backend from accidentally or maliciously triggering navigation to arbitrary routes.

## Who/what does this impact?

- `src/lib/notifications/notification-data.schema.ts` — new module
- `src/lib/notifications/handle-notification-navigation.ts` — new module
- `src/lib/context/notification-context.tsx` — `handleNotificationTap` stub replaced with `handleNotificationNavigation`
- Depends on M005/M008
- `transaction-details/onchain` requires full `transactionData` JSON — passing `id` alone is not yet supported (resolver not implemented)
- Backoffice (ticket 029) must align `screen` values with `ALLOWED_SCREENS`

## How did you test this?

- Tap with `"screen": "settings"` → settings screen opens
- Tap with `"screen": "transaction-details/onchain"` + full `transactionData` → detail screen opens with data
- Tap with unknown screen `"admin/delete-wallet"` → falls back to home, terminal shows warning
- Tap with `"url": "https://grimm.app"` → browser opens
- Cold start tap → correct screen after 500ms delay
- No crash on missing or malformed `data`