### PR TITLE
feat: implement notification permission request in onboarding flow an…

### DIFF
--- a/src/app/__tests__/onboarding.test.tsx
+++ b/src/app/__tests__/onboarding.test.tsx
@@ -60,9 +60,17 @@ jest.mock('expo-router', () => {
   };
 });
 
+const mockRequestNotificationPermissions = jest.fn().mockResolvedValue(true);
+
+jest.mock('@/lib/notifications/register-device', () => ({
+  requestNotificationPermissions: (...args: unknown[]) => mockRequestNotificationPermissions(...args),
+}));
+
 afterEach(() => {
   cleanup();
   mockPush.mockClear();
+  mockRequestNotificationPermissions.mockClear();
+  mockRequestNotificationPermissions.mockResolvedValue(true);
 });
 
 describe('Onboarding screen', () => {
@@ -81,7 +89,27 @@ describe('Onboarding screen', () => {
     expect(screen.getByTestId('onboarding-privacy-text')).toBeOnTheScreen();
   });
 
-  it('navigates to create-or-import-seed when tapping get started', async () => {
+  it('requests notification permission then navigates when tapping get started', async () => {
+    const { user } = setup(<Onboarding />);
+
+    await user.press(screen.getByTestId('onboarding-get-started'));
+
+    expect(mockRequestNotificationPermissions).toHaveBeenCalled();
+    expect(mockPush).toHaveBeenCalledWith('/auth/create-or-import-seed');
+  });
+
+  it('continues navigation when notification permission is denied', async () => {
+    mockRequestNotificationPermissions.mockResolvedValue(false);
+    const { user } = setup(<Onboarding />);
+
+    await user.press(screen.getByTestId('onboarding-get-started'));
+
+    expect(mockRequestNotificationPermissions).toHaveBeenCalled();
+    expect(mockPush).toHaveBeenCalledWith('/auth/create-or-import-seed');
+  });
+
+  it('continues navigation when notification permission request fails', async () => {
+    mockRequestNotificationPermissions.mockRejectedValue(new Error('permission error'));
     const { user } = setup(<Onboarding />);
 
     await user.press(screen.getByTestId('onboarding-get-started'));

--- a/src/app/onboarding.tsx
+++ b/src/app/onboarding.tsx
@@ -1,12 +1,13 @@
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { Stack, useRouter } from 'expo-router';
 import { useColorScheme } from 'nativewind';
-import React, { memo } from 'react';
+import React, { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Pressable, View } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import { Button, colors, FocusAwareStatusBar, Image, SafeAreaView, Text } from '@/components/ui';
+import { requestNotificationPermissions } from '@/lib/notifications/register-device';
 import { theme } from '@/lib/theme-classes';
 
 const Logo = memo(() => <Image className="size-32" source={require('@/assets/images/logo.png')} />);
@@ -27,13 +28,14 @@ const WelcomeText = memo(() => {
 
 interface FooterProps {
   onGetStarted: () => void;
+  loading?: boolean;
 }
 
-const Footer = memo(({ onGetStarted }: FooterProps) => {
+const Footer = memo(({ onGetStarted, loading }: FooterProps) => {
   const { t } = useTranslation();
   return (
     <>
-      <Button testID="onboarding-get-started" label={t('onboarding.getStarted')} onPress={onGetStarted} fullWidth variant="secondary" textClassName="text-base text-white" size="lg" />
+      <Button testID="onboarding-get-started" label={t('onboarding.getStarted')} onPress={onGetStarted} loading={loading} fullWidth variant="secondary" textClassName="text-base text-white" size="lg" />
       <Text testID="onboarding-agreement-text" className={`my-4 text-center ${theme.textSecondary}`}>
         {t('onboarding.agreementText')}{' '}
         <Text testID="onboarding-terms-text" className="font-semibold text-primary-600 underline dark:text-primary-400">
@@ -53,10 +55,22 @@ function Onboarding() {
   const { t } = useTranslation();
   const { colorScheme } = useColorScheme();
   const helpIconColor = colorScheme === 'dark' ? colors.charcoal[300] : colors.neutral[500];
+  const [isContinuing, setIsContinuing] = useState(false);
 
-  const handleGetStarted = React.useCallback(() => {
-    router.push('/auth/create-or-import-seed');
-  }, [router]);
+  const handleGetStarted = React.useCallback(async () => {
+    if (isContinuing) return;
+
+    setIsContinuing(true);
+    try {
+      // Prompt only if the OS can still ask; if already refused, continue without blocking
+      await requestNotificationPermissions();
+    } catch (error) {
+      console.warn('[onboarding] Notification permission request failed', error);
+    } finally {
+      router.push('/auth/create-or-import-seed');
+      setIsContinuing(false);
+    }
+  }, [isContinuing, router]);
 
   return (
     <SafeAreaProvider>
@@ -88,7 +102,7 @@ function Onboarding() {
             </View>
           </View>
           <View>
-            <Footer onGetStarted={handleGetStarted} />
+            <Footer onGetStarted={handleGetStarted} loading={isContinuing} />
           </View>
         </View>
       </SafeAreaView>

--- a/src/lib/breez/unclaimed-deposits-log.ts
+++ b/src/lib/breez/unclaimed-deposits-log.ts
@@ -65,12 +65,10 @@ export function formatDepositsSummary(deposits: DepositInfo[]): string {
 }
 
 export function logUnclaimedDeposits(deposits: DepositInfo[], source: string): void {
-  console.warn(`${UNCLAIMED_DEPOSITS_LOG_PREFIX} [${source}] count: ${deposits.length}`);
+  // Skip empty refreshes — they run on a timer and spam the console.
+  if (deposits.length === 0) return;
 
-  if (deposits.length === 0) {
-    console.warn(`${UNCLAIMED_DEPOSITS_LOG_PREFIX} [${source}] none pending or unclaimed`);
-    return;
-  }
+  console.warn(`${UNCLAIMED_DEPOSITS_LOG_PREFIX} [${source}] count: ${deposits.length}`);
 
   deposits.forEach((deposit, index) => {
     console.warn(`${UNCLAIMED_DEPOSITS_LOG_PREFIX} [${source}] ${formatDepositForLog(deposit, index)}`);

--- a/src/lib/notifications/__tests__/register-device.test.ts
+++ b/src/lib/notifications/__tests__/register-device.test.ts
@@ -6,7 +6,7 @@ import axios from 'axios';
 import { registerDevice, updateDevice } from '@/api/notifications';
 import { isNotificationServiceConfigured } from '@/lib/notifications/config';
 import { clearStoredDeviceId, getStoredDeviceId, getStoredPushToken, setStoredDeviceId, setStoredPushToken } from '@/lib/notifications/device-storage';
-import { registerDeviceWithNotificationService } from '@/lib/notifications/register-device';
+import { registerDeviceWithNotificationService, requestNotificationPermissions } from '@/lib/notifications/register-device';
 
 jest.mock('@/api/notifications');
 jest.mock('@/lib/notifications/config');
@@ -45,8 +45,8 @@ describe('registerDeviceWithNotificationService', () => {
     jest.clearAllMocks();
 
     mockIsConfigured.mockReturnValue(true);
-    (Notifications.getPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'granted' });
-    (Notifications.requestPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'granted' });
+    (Notifications.getPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'granted', canAskAgain: true });
+    (Notifications.requestPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'granted', canAskAgain: true });
     (Notifications.getExpoPushTokenAsync as jest.Mock).mockResolvedValue({ data: 'ExponentPushToken[test]' });
     (Notifications.setNotificationChannelAsync as jest.Mock).mockResolvedValue(undefined);
     (Localization.getLocales as jest.Mock).mockReturnValue([{ languageCode: 'en' }]);
@@ -68,7 +68,7 @@ describe('registerDeviceWithNotificationService', () => {
   });
 
   it('skips when permission is not granted without requesting it', async () => {
-    (Notifications.getPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'denied' });
+    (Notifications.getPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'denied', canAskAgain: false });
 
     await expect(registerDeviceWithNotificationService()).resolves.toEqual({
       status: 'skipped',
@@ -191,8 +191,8 @@ describe('registerDeviceWithNotificationService', () => {
     expect(mockRegisterDevice).toHaveBeenCalled();
   });
 
-  it('requests permission when requestPermission option is true', async () => {
-    (Notifications.getPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'denied' });
+  it('requests permission when requestPermission option is true and OS can ask again', async () => {
+    (Notifications.getPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'undetermined', canAskAgain: true });
     (Notifications.requestPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'granted' });
     mockGetStoredDeviceId.mockResolvedValue(null);
     mockGetStoredPushToken.mockResolvedValue(null);
@@ -211,6 +211,58 @@ describe('registerDeviceWithNotificationService', () => {
       result: expect.objectContaining({ deviceId: 'new-device-id' }),
     });
 
-    expect(Notifications.requestPermissionsAsync).toHaveBeenCalled();
+    expect(Notifications.requestPermissionsAsync).toHaveBeenCalledWith({
+      ios: {
+        allowAlert: true,
+        allowBadge: true,
+        allowSound: true,
+      },
+    });
+  });
+
+  it('does not re-prompt when permission was already denied and cannot ask again', async () => {
+    (Notifications.getPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'denied', canAskAgain: false });
+
+    await expect(registerDeviceWithNotificationService({ requestPermission: true })).resolves.toEqual({
+      status: 'skipped',
+      reason: 'permission_denied',
+    });
+
+    expect(Notifications.requestPermissionsAsync).not.toHaveBeenCalled();
+  });
+});
+
+describe('requestNotificationPermissions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (Notifications.setNotificationChannelAsync as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  it('returns true without prompting when already granted', async () => {
+    (Notifications.getPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'granted', canAskAgain: true });
+
+    await expect(requestNotificationPermissions()).resolves.toBe(true);
+    expect(Notifications.requestPermissionsAsync).not.toHaveBeenCalled();
+  });
+
+  it('returns false without prompting when already denied', async () => {
+    (Notifications.getPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'denied', canAskAgain: false });
+
+    await expect(requestNotificationPermissions()).resolves.toBe(false);
+    expect(Notifications.requestPermissionsAsync).not.toHaveBeenCalled();
+  });
+
+  it('prompts when permission is undetermined', async () => {
+    (Notifications.getPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'undetermined', canAskAgain: true });
+    (Notifications.requestPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'granted', canAskAgain: true });
+
+    await expect(requestNotificationPermissions()).resolves.toBe(true);
+    expect(Notifications.requestPermissionsAsync).toHaveBeenCalledWith({
+      ios: {
+        allowAlert: true,
+        allowBadge: true,
+        allowSound: true,
+      },
+    });
   });
 });

--- a/src/lib/notifications/register-device.ts
+++ b/src/lib/notifications/register-device.ts
@@ -54,31 +54,46 @@ export async function hasNotificationPermission(): Promise<boolean> {
   return status === 'granted';
 }
 
+/**
+ * Requests notification permission when the OS can still show the system prompt.
+ * If the user already refused (canAskAgain === false), returns false without prompting —
+ * they can re-enable later from app/settings.
+ * Works on both iOS and Android (POST_NOTIFICATIONS on Android 13+).
+ */
 export async function requestNotificationPermissions(): Promise<boolean> {
-  const { status: existingStatus } = await Notifications.getPermissionsAsync();
+  const { status: existingStatus, canAskAgain } = await Notifications.getPermissionsAsync();
+  logPermissionStatus(existingStatus);
 
   if (existingStatus === 'granted') return true;
 
-  const { status } = await Notifications.requestPermissionsAsync();
-  return status === 'granted';
-}
-
-async function ensureNotificationPermission(requestPermission: boolean): Promise<boolean> {
-  const { status } = await Notifications.getPermissionsAsync();
-  logPermissionStatus(status);
-
-  if (status === 'granted') {
-    return true;
-  }
-
-  if (!requestPermission) {
+  // Already refused — do not re-prompt; continue silently
+  if (!canAskAgain) {
+    logPermissionRequest(false);
     return false;
   }
 
-  const { status: requestedStatus } = await Notifications.requestPermissionsAsync();
-  const granted = requestedStatus === 'granted';
+  await ensureAndroidNotificationChannel();
+
+  const { status } = await Notifications.requestPermissionsAsync({
+    ios: {
+      allowAlert: true,
+      allowBadge: true,
+      allowSound: true,
+    },
+  });
+  const granted = status === 'granted';
   logPermissionRequest(granted);
   return granted;
+}
+
+async function ensureNotificationPermission(requestPermission: boolean): Promise<boolean> {
+  if (requestPermission) {
+    return requestNotificationPermissions();
+  }
+
+  const { status } = await Notifications.getPermissionsAsync();
+  logPermissionStatus(status);
+  return status === 'granted';
 }
 
 export async function getExpoPushToken(): Promise<string> {


### PR DESCRIPTION
## What does this do?

Prompts for notification permission during onboarding: when the user taps **Get started**, `requestNotificationPermissions()` is called before navigating to `/auth/create-or-import-seed`. The button shows a loading state while the OS dialog is open, and navigation always proceeds — whether the permission is granted, denied, or the request fails.

Refactors `requestNotificationPermissions()` in `register-device.ts` to be the single permission-request path:
- Reads `canAskAgain` from `getPermissionsAsync()` and returns `false` without prompting when the user already refused permanently (no repeated OS dialogs).
- Ensures the Android notification channel exists before prompting (required on Android 13+ for `POST_NOTIFICATIONS`).
- Passes explicit iOS options (`allowAlert`, `allowBadge`, `allowSound`).
- `ensureNotificationPermission()` now delegates to it instead of duplicating the logic.

Also silences `logUnclaimedDeposits()` when the deposit list is empty — the refresh runs on a timer and was spamming the console.

## Why did you do this?

Since M004, device registration runs at app start with `requestPermission: false`, and nothing in the app ever asked the user for notification permission. On a fresh install the status stayed `undetermined`, so `registerDeviceWithNotificationService()` was always skipped with `permission_denied` and the device never got a push token. Onboarding is the natural place to ask once: the user is already in a setup flow, and the registration on the next `NotificationProvider` init picks up the granted status automatically.

Respecting `canAskAgain` avoids calling `requestPermissionsAsync()` on a permanently denied status, which is a silent no-op on iOS and a bad UX pattern on Android.

## Who/what does this impact?

- `src/app/onboarding.tsx` — `handleGetStarted` is now async; `Footer` receives a `loading` prop
- `src/lib/notifications/register-device.ts` — `requestNotificationPermissions()` behaviour changed (no re-prompt when `canAskAgain === false`); `ensureNotificationPermission()` now reuses it
- `src/lib/breez/unclaimed-deposits-log.ts` — no more `count: 0` / `none pending` log lines on empty refreshes
- Depends on M004 (device registration) / M005 (`NotificationProvider`)
- Existing users who already onboarded will not see the prompt — they can enable notifications from the settings screen (M006)

## How did you test this?

- Unit tests: `src/app/__tests__/onboarding.test.tsx` (permission granted / denied / request throws → navigation always happens) and `src/lib/notifications/__tests__/register-device.test.ts` (already granted → no prompt, `canAskAgain: false` → no prompt, `undetermined` → prompt with iOS options) — 16/16 passing
- `tsc --noEmit` and `eslint` clean
- Manual: fresh install → tapped **Get started** → OS permission dialog shown → navigation to seed screen in all three cases (allow, deny, dismiss); relaunch after allow → terminal confirmed `POST /devices` with an Expo push token
