### PR TITLE
fix: update dependencies to address high vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -187,13 +187,22 @@
       "qs": "6.14.1",
       "file-type": "16.5.4",
       "postcss": "8.5.24",
-      "brace-expansion": "5.0.8",
+      "brace-expansion": "5.0.9",
+      "js-yaml@^3.0.0": "3.15.1",
+      "js-yaml@^4.0.0": "4.3.1",
+      "nanoid@^3.0.0": "3.3.18",
       "tar": "^7.5.18",
       "tough-cookie": "4.1.3"
     },
     "patchedDependencies": {
       "@breeztech/breez-sdk-spark-react-native@0.15.1": "patches/@breeztech__breez-sdk-spark-react-native@0.15.1.patch",
-      "brace-expansion@5.0.8": "patches/brace-expansion@5.0.8.patch"
+      "brace-expansion@5.0.9": "patches/brace-expansion@5.0.9.patch"
+    },
+    "auditConfig": {
+      "ignoreGhsas": [
+        "GHSA-w3rx-r6r6-pgpr",
+        "GHSA-5p2g-fcmc-qvqq"
+      ]
     }
   },
   "expo": {

--- a/patches/brace-expansion@5.0.9.patch
+++ b/patches/brace-expansion@5.0.9.patch
@@ -1,8 +1,8 @@
 diff --git a/dist/commonjs/index.js b/dist/commonjs/index.js
-index be9df86be09c7655787a65c55ae6da01858894c3..cdadba4d1946cbe3449f78abf4300af093a8a11d 100644
+index 869a6bee23807b9f01c18c99ab8e952b4b242f97..684259e2b562d343315dc280bbed1120533213b9 100644
 --- a/dist/commonjs/index.js
 +++ b/dist/commonjs/index.js
-@@ -260,4 +260,9 @@ function expand_(str, max, maxLength, isTop) {
+@@ -286,4 +286,9 @@ function expand_(str, max, maxLength, isTop) {
      }
      return acc;
  }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,10 @@ overrides:
   qs: 6.14.1
   file-type: 16.5.4
   postcss: 8.5.24
-  brace-expansion: 5.0.8
+  brace-expansion: 5.0.9
+  js-yaml@^3.0.0: 3.15.1
+  js-yaml@^4.0.0: 4.3.1
+  nanoid@^3.0.0: 3.3.18
   tar: ^7.5.18
   tough-cookie: 4.1.3
 
@@ -33,9 +36,9 @@ patchedDependencies:
   '@breeztech/breez-sdk-spark-react-native@0.15.1':
     hash: 5s3xcy4sq2fjunrs5bstm5t3u4
     path: patches/@breeztech__breez-sdk-spark-react-native@0.15.1.patch
-  brace-expansion@5.0.8:
-    hash: njlc7onuvqh5qtmuzamfeqmb4m
-    path: patches/brace-expansion@5.0.8.patch
+  brace-expansion@5.0.9:
+    hash: z3g7fhoivhk74vvuxznduagdja
+    path: patches/brace-expansion@5.0.9.patch
 
 importers:
 
@@ -2543,8 +2546,8 @@ packages:
     resolution: {integrity: sha512-apC2+fspHGI3mMKj+dGevkGo/tCqVB8jMb6i+OX+E29p0Iposz07fABkRIfVUPNd5A5VbuOz1bZbnmkKLYF+wQ==}
     engines: {node: '>= 5.10.0'}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -4820,12 +4823,12 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsc-safe-url@0.2.4:
@@ -5304,8 +5307,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -8170,7 +8173,7 @@ snapshots:
       globals: 13.24.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -8440,7 +8443,7 @@ snapshots:
     dependencies:
       '@babel/code-frame': 7.29.7
       chalk: 4.1.2
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
 
   '@formatjs/ecma402-abstract@2.3.6':
     dependencies:
@@ -8481,7 +8484,7 @@ snapshots:
 
   '@gorhom/portal@1.0.14(react-native@0.79.6(@babel/core@7.29.7)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)':
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       react: 19.0.0
       react-native: 0.79.6(@babel/core@7.29.7)(@types/react@19.0.14)(react@19.0.0)
 
@@ -8648,7 +8651,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.6': {}
@@ -9318,7 +9321,7 @@ snapshots:
       '@react-navigation/routers': 7.6.4
       escape-string-regexp: 4.0.0
       fast-deep-equal: 3.1.3
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       query-string: 7.1.3
       react: 19.0.0
       react-is: 19.2.8
@@ -9354,7 +9357,7 @@ snapshots:
       '@react-navigation/core': 7.21.11(react@19.0.0)
       escape-string-regexp: 4.0.0
       fast-deep-equal: 3.1.3
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       react: 19.0.0
       react-native: 0.79.6(@babel/core@7.29.7)(@types/react@19.0.14)(react@19.0.0)
       standard-navigation: 0.0.8(react@19.0.0)
@@ -9362,7 +9365,7 @@ snapshots:
 
   '@react-navigation/routers@7.6.4':
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
 
   '@rtsao/scc@1.1.0': {}
 
@@ -10210,7 +10213,7 @@ snapshots:
     dependencies:
       big-integer: 1.6.52
 
-  brace-expansion@5.0.8(patch_hash=njlc7onuvqh5qtmuzamfeqmb4m):
+  brace-expansion@5.0.9(patch_hash=z3g7fhoivhk74vvuxznduagdja):
     dependencies:
       balanced-match: 4.0.4
 
@@ -10559,13 +10562,13 @@ snapshots:
     dependencies:
       import-fresh: 2.0.0
       is-directory: 0.3.1
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       parse-json: 4.0.0
 
   cosmiconfig@8.3.6(typescript@5.8.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -10575,7 +10578,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.8.3
@@ -11332,7 +11335,7 @@ snapshots:
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
@@ -12948,12 +12951,12 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.15.0:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -13493,15 +13496,15 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 5.0.8(patch_hash=njlc7onuvqh5qtmuzamfeqmb4m)
+      brace-expansion: 5.0.9(patch_hash=z3g7fhoivhk74vvuxznduagdja)
 
   minimatch@8.0.7:
     dependencies:
-      brace-expansion: 5.0.8(patch_hash=njlc7onuvqh5qtmuzamfeqmb4m)
+      brace-expansion: 5.0.9(patch_hash=z3g7fhoivhk74vvuxznduagdja)
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 5.0.8(patch_hash=njlc7onuvqh5qtmuzamfeqmb4m)
+      brace-expansion: 5.0.9(patch_hash=z3g7fhoivhk74vvuxznduagdja)
 
   minimist@1.2.8: {}
 
@@ -13546,7 +13549,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -14045,7 +14048,7 @@ snapshots:
 
   postcss@8.5.24:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
## What does this do?

Fixes the `security-audit` workflow (`pnpm audit --prod --audit-level=high`), which is currently failing on `master` with 6 high-severity advisories. All changes are in `package.json` / `pnpm-lock.yaml` — no application code is touched.

**Bumped via `pnpm.overrides`** (all transitive, no direct dependency changed):

| Package | Before | After | Advisory |
|---|---|---|---|
| `brace-expansion` | 5.0.8 | 5.0.9 | GHSA-rgw5-rvv9-x895 — DoS via unbounded intermediate arrays |
| `js-yaml` (3.x) | 3.15.0 | 3.15.1 | GHSA-5p4m-2wfm-xmqj — quadratic CPU in `!!omap` resolution |
| `js-yaml` (4.x) | 4.3.0 | 4.3.1 | GHSA-5p4m-2wfm-xmqj — same, 4.x line |
| `nanoid` | 3.3.16 | 3.3.18 | GHSA-2v37-7h3g-55p8 — custom generators loop indefinitely when size is 0 |

`js-yaml` uses pnpm's range-scoped override syntax (`js-yaml@^3.0.0` / `js-yaml@^4.0.0`) so both major lines are pinned independently without forcing 3.x consumers onto 4.x.

**Patch renamed**: `patches/brace-expansion@5.0.8.patch` → `patches/brace-expansion@5.0.9.patch`. The patch content is unchanged (CJS default export shim for `minimatch@3` and other legacy consumers); only the target hash/line offset was regenerated for 5.0.9.

**Ignored via `pnpm.auditConfig.ignoreGhsas`**:
- `GHSA-w3rx-r6r6-pgpr` — `image-size` ICNS parser infinite loop
- `GHSA-5p2g-fcmc-qvqq` — `image-size` JXL/HEIF parser infinite loop

## Why did you do this?

The scheduled `security-audit` workflow has been red since these advisories were published. Four of the six high findings had a patched release available, so they are resolved by simply pinning the fixed version through overrides.

The two `image-size` advisories are ignored rather than fixed because **no patched version exists** (advisory lists `first_patched_version: none` for `<= 2.0.2`). `image-size@1.2.1` is pulled in exclusively by `metro@0.82.5` (via `react-native@0.79.6` → `@react-native/community-cli-plugin`), i.e. the bundler/dev-server. It only parses image assets from our own repo at bundle time and never processes untrusted input at runtime, so the DoS vector does not apply to the shipped app. Ignoring by GHSA id (rather than by package) means any *new* `image-size` advisory will still surface.

## Who/what does this impact?

- `.github/workflows/security-audit.yml` — goes green (see below)
- Anyone running `pnpm install` after pulling — lockfile changes, plain reinstall, no migration
- `brace-expansion` patch consumers (`minimatch@3` via `glob@7`, used by RN codegen / jest) — behaviour identical, only the version pin moved
- Remaining known findings, **not addressed here** (all outside the CI gate):
  - `fast-uri@3.1.4` (high, GHSA-7p8r-x3mc-p8w7) — dev-only via `@commitlint/cli` → `ajv@8`, excluded by `--prod`. Patched in `>=3.1.5`; could be added as an override in a follow-up.
  - 7 moderate (`@babel/runtime`, `ajv`, `file-type`, `uuid`, `undici` ×3) — below the `--audit-level=high` threshold.
- Unrelated: `patches/@breeztech__breez-sdk-spark-react-native@0.15.0.patch` is stale (0.15.1 is the one referenced in `package.json`) and could be deleted in a separate cleanup.

## How did you test this?

- `pnpm install --frozen-lockfile` — succeeds, patch applies cleanly to 5.0.9
- `pnpm ls` confirms `brace-expansion 5.0.9`, `js-yaml 3.15.1` + `4.3.1`, `nanoid 3.3.18` in the tree
- Exact CI command `pnpm audit --prod --audit-level=high`:
  - `master`: 13 vulnerabilities (7 moderate | 6 high) — **exit 1**
  - this branch: 9 vulnerabilities (7 moderate | 2 high, both `image-size` and ignored) — **exit 0**
- `tsc --noEmit` — clean
- Full jest suite — 42 suites, 297 passed, 1 skipped
