### PR TITLE
feat: add Lightning invoice expiry settings and countdown functionality

### DIFF
--- a/src/app/(app)/settings.tsx
+++ b/src/app/(app)/settings.tsx
@@ -57,6 +57,12 @@ export default function Settings() {
                 <SettingsItem icon="globe" title={t('settings.general.country.title')} subtitle={t('settings.general.country.subtitle')} onPress={() => router.push('/settings/country')} />
                 <SettingsItem icon="language" title={t('settings.general.language.title')} subtitle={t('settings.general.language.subtitle')} onPress={() => router.push('/settings/language')} />
                 <SettingsItem icon="options-sharp" title={t('settings.general.bitcoinUnit.title')} subtitle={t('settings.general.bitcoinUnit.subtitle')} onPress={() => router.push('/settings/bitcoin-unit')} />
+                <SettingsItem
+                  icon="time-outline"
+                  title={t('settings.general.lnInvoiceExpiry.title')}
+                  subtitle={t('settings.general.lnInvoiceExpiry.subtitle')}
+                  onPress={() => router.push('/settings/ln-invoice-expiry')}
+                />
                 <SettingsItem icon="at" title={t('settings.general.lnAddress.title')} subtitle={t('settings.general.lnAddress.subtitle')} onPress={() => router.push('/settings/ln-address')} />
               </View>
             </View>

--- a/src/app/receive/__tests__/ln-qrcode.test.tsx
+++ b/src/app/receive/__tests__/ln-qrcode.test.tsx
@@ -1,0 +1,220 @@
+import { act } from '@testing-library/react-native';
+import React from 'react';
+
+import { cleanup, fireEvent, screen, setup, waitFor } from '@/lib/test-utils';
+
+// Native module mocks (must be before component import)
+jest.mock('@breeztech/breez-sdk-spark-react-native', () => ({
+  PaymentStatus: { Completed: 'completed' },
+  PaymentType: { Receive: 'receive' },
+}));
+
+jest.mock('bdk-rn', () => require('@/lib/bdk/__tests__/helpers/mock-bdk-rn'));
+
+jest.mock('@/api', () => ({
+  supportedBitcoinCurrencies: [],
+}));
+
+jest.mock('react-native-safe-area-context', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    SafeAreaProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    SafeAreaView: ({ children, ...props }: { children: React.ReactNode }) => <View {...props}>{children}</View>,
+    useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 0, left: 0 }),
+  };
+});
+
+jest.mock('@expo/vector-icons', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return {
+    Ionicons: (props: Record<string, unknown>) => <Text>{String(props.name)}</Text>,
+  };
+});
+
+jest.mock('@expo/vector-icons/Ionicons', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return (props: Record<string, unknown>) => <Text>{String(props.name)}</Text>;
+});
+
+jest.mock('@/components/ui/focus-aware-status-bar', () => ({
+  FocusAwareStatusBar: () => null,
+}));
+
+jest.mock('@/components/back-button', () => ({
+  HeaderLeft: () => null,
+}));
+
+// `t` must keep a stable identity: the screen lists it in a useCallback dependency array.
+const mockT = (key: string) => key;
+
+jest.mock('react-i18next', () => ({
+  initReactI18next: {
+    type: '3rdParty',
+    init: jest.fn(),
+  },
+  useTranslation: () => ({ t: mockT }),
+}));
+
+let mockParams: Record<string, string> = { satsAmount: '1000', type: 'lightning' };
+const mockDismissAll = jest.fn();
+const mockReplace = jest.fn();
+
+jest.mock('expo-router', () => {
+  const React = require('react');
+  return {
+    useLocalSearchParams: () => mockParams,
+    useRouter: () => ({ dismissAll: mockDismissAll, replace: mockReplace }),
+    Stack: {
+      Screen: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    },
+  };
+});
+
+jest.mock('react-native-flash-message', () => ({
+  showMessage: jest.fn(),
+}));
+
+jest.mock('react-native-qrcode-svg', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return (props: Record<string, unknown>) => <View testID="qr-code">{String(props.value)}</View>;
+});
+
+const mockReceiveBolt11 = jest.fn();
+const mockReceiveBitcoinAddress = jest.fn();
+
+jest.mock('@/lib/context/breez-context', () => ({
+  useBreez: () => ({
+    receiveBolt11: mockReceiveBolt11,
+    receiveBitcoinAddress: mockReceiveBitcoinAddress,
+  }),
+}));
+
+jest.mock('@/lib/context/bitcoin-prices-context', () => ({
+  useBitcoin: () => ({
+    bitcoinPrices: { XAF: { last: 36000000, buy: 36000000, sell: 36000000, symbol: 'FCFA' } },
+  }),
+}));
+
+jest.mock('@/lib/context', () => ({
+  AppContext: require('react').createContext({
+    selectedCountry: { currency: 'XAF', name: 'Cameroon', isoCode: 'CM' },
+    lnInvoiceExpirySecs: 3600,
+  }),
+}));
+
+jest.mock('@/lib', () => {
+  const countdown = jest.requireActual('@/lib/hooks/use-countdown');
+  return {
+    convertBitcoinToFiat: jest.fn(() => 0),
+    getFiatCurrency: jest.fn(() => 'XAF'),
+    splitStringIntoChunks: jest.fn((value: string, size: number) => (value ? (value.match(new RegExp(`.{1,${size}}`, 'g')) ?? []) : [])),
+    formatRemainingTime: countdown.formatRemainingTime,
+    useCountdown: countdown.useCountdown,
+  };
+});
+
+import { AppContext } from '@/lib/context';
+
+import ReceivePaymentScreen from '../ln-qrcode';
+
+const renderWithContext = (lnInvoiceExpirySecs: number) =>
+  setup(
+    <AppContext.Provider value={{ selectedCountry: { currency: 'XAF', name: 'Cameroon', isoCode: 'CM' }, lnInvoiceExpirySecs } as any}>
+      <ReceivePaymentScreen />
+    </AppContext.Provider>,
+  );
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+  mockParams = { satsAmount: '1000', type: 'lightning' };
+  mockReceiveBolt11.mockResolvedValue({ paymentRequest: 'lnbc10u1ptest', fee: BigInt(0) });
+  mockReceiveBitcoinAddress.mockResolvedValue({ paymentRequest: 'bc1qtestaddress', fee: BigInt(0) });
+});
+
+afterEach(() => {
+  cleanup();
+  jest.clearAllMocks();
+  jest.useRealTimers();
+});
+
+describe('ReceivePaymentScreen (ln-qrcode)', () => {
+  it('generates the invoice with the expiry configured in settings', async () => {
+    renderWithContext(1800);
+
+    await waitFor(() => expect(screen.getByTestId('qr-code')).toBeOnTheScreen());
+
+    expect(mockReceiveBolt11).toHaveBeenCalledTimes(1);
+    expect(mockReceiveBolt11).toHaveBeenCalledWith(expect.any(String), 1000, 1800);
+    expect(screen.getByTestId('qr-code')).toHaveTextContent('LNBC10U1PTEST');
+  });
+
+  it('falls back to the context default expiry', async () => {
+    renderWithContext(3600);
+
+    await waitFor(() => expect(screen.getByTestId('qr-code')).toBeOnTheScreen());
+
+    expect(mockReceiveBolt11).toHaveBeenCalledWith(expect.any(String), 1000, 3600);
+  });
+
+  it('shows a countdown matching the configured expiry and ticks down', async () => {
+    renderWithContext(1800);
+
+    await waitFor(() => expect(screen.getByTestId('invoice-countdown')).toBeOnTheScreen());
+    expect(screen.getByTestId('invoice-countdown')).toHaveTextContent(/paymentDetails\.expiresIn (30:00|29:59)/);
+
+    act(() => {
+      jest.advanceTimersByTime(60_000);
+    });
+
+    expect(screen.getByTestId('invoice-countdown')).toHaveTextContent(/paymentDetails\.expiresIn 29:0\d/);
+  });
+
+  it('marks the invoice as expired, hides the QR code and allows regenerating', async () => {
+    renderWithContext(600);
+
+    await waitFor(() => expect(screen.getByTestId('qr-code')).toBeOnTheScreen());
+
+    act(() => {
+      jest.advanceTimersByTime(601_000);
+    });
+
+    expect(screen.getByTestId('invoice-countdown')).toHaveTextContent('paymentDetails.expired');
+    expect(screen.queryByTestId('qr-code')).toBeNull();
+    expect(screen.queryByText('receive_payment.scan_text')).toBeNull();
+    expect(screen.getByTestId('regenerate-invoice')).toBeOnTheScreen();
+
+    fireEvent.press(screen.getByTestId('regenerate-invoice'));
+
+    await waitFor(() => expect(mockReceiveBolt11).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.getByTestId('qr-code')).toBeOnTheScreen());
+    expect(screen.getByTestId('invoice-countdown')).toHaveTextContent(/paymentDetails\.expiresIn (10:00|9:59)/);
+  });
+
+  it('does not show a countdown nor call receiveBolt11 for on-chain receive', async () => {
+    mockParams = { satsAmount: '0', type: 'onchain' };
+    renderWithContext(3600);
+
+    await waitFor(() => expect(screen.getByTestId('qr-code')).toBeOnTheScreen());
+
+    expect(mockReceiveBitcoinAddress).toHaveBeenCalledTimes(1);
+    expect(mockReceiveBolt11).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('invoice-countdown')).toBeNull();
+  });
+
+  it('shows an error state when the amount is invalid', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockParams = { satsAmount: '0', type: 'lightning' };
+    renderWithContext(3600);
+
+    await waitFor(() => expect(screen.getByText('receive_payment.error_title')).toBeOnTheScreen());
+
+    expect(screen.getByText('receive_payment.invalid_amount')).toBeOnTheScreen();
+    expect(mockReceiveBolt11).not.toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/src/app/receive/ln-qrcode.tsx
+++ b/src/app/receive/ln-qrcode.tsx
@@ -12,7 +12,7 @@ import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { HeaderLeft } from '@/components/back-button';
 import { HeaderTitle } from '@/components/header-title';
 import { Button, colors, FocusAwareStatusBar, SafeAreaView, Text, View } from '@/components/ui';
-import { convertBitcoinToFiat, getFiatCurrency, splitStringIntoChunks } from '@/lib';
+import { convertBitcoinToFiat, formatRemainingTime, getFiatCurrency, splitStringIntoChunks, useCountdown } from '@/lib';
 import { AppContext } from '@/lib/context';
 import { useBitcoin } from '@/lib/context/bitcoin-prices-context';
 import { useBreez } from '@/lib/context/breez-context';
@@ -26,7 +26,7 @@ type SearchParams = {
 
 export default function ReceivePaymentScreen() {
   const { t } = useTranslation();
-  const { selectedCountry } = useContext(AppContext);
+  const { selectedCountry, lnInvoiceExpirySecs } = useContext(AppContext);
   const router = useRouter();
   const { bitcoinPrices } = useBitcoin();
   const { receiveBolt11, receiveBitcoinAddress } = useBreez();
@@ -35,6 +35,8 @@ export default function ReceivePaymentScreen() {
   const [paymentRequest, setPaymentRequest] = useState<string>('');
   const [fees, setFees] = useState<bigint>(BigInt(0));
   const [error, setError] = useState<string>('');
+  const [expiresAt, setExpiresAt] = useState<number | null>(null);
+  const { remainingSecs, isExpired } = useCountdown(type === 'lightning' ? expiresAt : null);
 
   const defaultNotes = t('receive_payment.default_note', { amount: Number(satsAmount).toLocaleString() });
   const selectedFiatCurrency = getFiatCurrency(selectedCountry);
@@ -43,6 +45,7 @@ export default function ReceivePaymentScreen() {
     try {
       setLoading(true);
       setError('');
+      setExpiresAt(null);
 
       if (type === 'onchain') {
         const receiveResponse = await receiveBitcoinAddress();
@@ -52,9 +55,10 @@ export default function ReceivePaymentScreen() {
         if (!satsAmount || parseInt(satsAmount, 10) <= 0) {
           throw new Error(t('receive_payment.invalid_amount'));
         }
-        const receiveResponse = await receiveBolt11(note || defaultNotes, parseInt(satsAmount, 10), 3600);
+        const receiveResponse = await receiveBolt11(note || defaultNotes, parseInt(satsAmount, 10), lnInvoiceExpirySecs);
         setPaymentRequest(receiveResponse.paymentRequest);
         setFees(receiveResponse.fee);
+        setExpiresAt(Date.now() + lnInvoiceExpirySecs * 1000);
       }
     } catch (err) {
       console.error('Error generating invoice:', err);
@@ -62,7 +66,7 @@ export default function ReceivePaymentScreen() {
     } finally {
       setLoading(false);
     }
-  }, [satsAmount, type, note, defaultNotes, t, receiveBolt11, receiveBitcoinAddress]);
+  }, [satsAmount, type, note, defaultNotes, t, receiveBolt11, receiveBitcoinAddress, lnInvoiceExpirySecs]);
 
   useEffect(() => {
     generatePaymentRequest();
@@ -176,11 +180,29 @@ export default function ReceivePaymentScreen() {
                   <View className="rounded-lg bg-white p-3 dark:bg-charcoal-900">
                     <Text className="text-sm text-gray-600 dark:text-charcoal-300">{note || defaultNotes}</Text>
                   </View>
+                  {remainingSecs !== null && (
+                    <View className="mt-3 flex-row items-center justify-center">
+                      <Ionicons name="time-outline" size={16} color={isExpired ? '#EF4444' : '#6B7280'} />
+                      <Text testID="invoice-countdown" className={`ml-1 text-sm ${isExpired ? 'text-red-500' : 'text-gray-500 dark:text-charcoal-400'}`}>
+                        {isExpired ? t('paymentDetails.expired') : `${t('paymentDetails.expiresIn')} ${formatRemainingTime(remainingSecs)}`}
+                      </Text>
+                    </View>
+                  )}
                 </View>
               </View>
             )}
             <View className="mb-8 items-center">
-              <View className="bg-white p-6 dark:bg-charcoal-900">{paymentRequest && <QRCode value={paymentRequest?.toUpperCase()} size={200} backgroundColor="white" color="black" />}</View>
+              {isExpired ? (
+                <View className="w-full items-center p-6">
+                  <Ionicons name="time-outline" size={48} color="#EF4444" />
+                  <Text className="mt-2 text-base font-semibold text-red-500">{t('paymentDetails.expired')}</Text>
+                  <View className="mt-4 w-full">
+                    <Button label={t('receive_payment.retry')} onPress={handleRetry} fullWidth={true} variant="secondary" textClassName="text-base text-white" size="lg" testID="regenerate-invoice" />
+                  </View>
+                </View>
+              ) : (
+                <View className="bg-white p-6 dark:bg-charcoal-900">{paymentRequest && <QRCode value={paymentRequest?.toUpperCase()} size={200} backgroundColor="white" color="black" />}</View>
+              )}
               {type === 'onchain' && (
                 <Pressable onPress={copyToClipboard} className="mx-4 flex flex-row flex-wrap justify-center">
                   {splitStringIntoChunks(paymentRequest?.toUpperCase(), 6).map((s) => (
@@ -190,16 +212,16 @@ export default function ReceivePaymentScreen() {
                   ))}
                 </Pressable>
               )}
-              <Text className="mt-4 text-center text-sm text-gray-500 dark:text-charcoal-400">{t('receive_payment.scan_text')}</Text>
+              {!isExpired && <Text className="mt-4 text-center text-sm text-gray-500 dark:text-charcoal-400">{t('receive_payment.scan_text')}</Text>}
             </View>
             <View className="flex flex-row justify-center">
               <View className="mx-4 flex items-center justify-center">
-                <Pressable className="mb-2 rounded-full bg-primary-600 p-3 text-white" onPress={copyToClipboard}>
+                <Pressable className={`mb-2 rounded-full p-3 text-white ${isExpired ? 'bg-gray-400' : 'bg-primary-600'}`} onPress={copyToClipboard} disabled={isExpired} testID="copy-payment-request">
                   <Ionicons name="copy" size={20} color="white" />
                 </Pressable>
               </View>
               <View className="mx-4 flex items-center justify-center">
-                <Pressable className="mb-2 rounded-full bg-primary-600 p-3 text-white" onPress={sharePaymentRequest}>
+                <Pressable className={`mb-2 rounded-full p-3 text-white ${isExpired ? 'bg-gray-400' : 'bg-primary-600'}`} onPress={sharePaymentRequest} disabled={isExpired} testID="share-payment-request">
                   <Ionicons name="share" size={20} color="white" />
                 </Pressable>
               </View>

--- a/src/app/settings/__tests__/ln-invoice-expiry.test.tsx
+++ b/src/app/settings/__tests__/ln-invoice-expiry.test.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+
+import { cleanup, screen, setup } from '@/lib/test-utils';
+
+// Native module mocks (must be before component import)
+jest.mock('@breeztech/breez-sdk-spark-react-native', () => ({
+  PaymentStatus: { Completed: 'completed' },
+  PaymentType: { Receive: 'receive' },
+}));
+
+jest.mock('bdk-rn', () => require('@/lib/bdk/__tests__/helpers/mock-bdk-rn'));
+
+jest.mock('@/api', () => ({
+  supportedBitcoinCurrencies: [],
+}));
+
+jest.mock('react-native-safe-area-context', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    SafeAreaProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    SafeAreaView: ({ children, ...props }: { children: React.ReactNode }) => <View {...props}>{children}</View>,
+    useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 0, left: 0 }),
+  };
+});
+
+jest.mock('@expo/vector-icons/Ionicons', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return (props: Record<string, unknown>) => <Text>{String(props.name)}</Text>;
+});
+
+jest.mock('@/components/ui/focus-aware-status-bar', () => ({
+  FocusAwareStatusBar: () => null,
+}));
+
+jest.mock('react-i18next', () => ({
+  initReactI18next: {
+    type: '3rdParty',
+    init: jest.fn(),
+  },
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('expo-router', () => {
+  const React = require('react');
+  return {
+    Stack: {
+      Screen: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    },
+  };
+});
+
+jest.mock('@/components/back-button', () => ({
+  HeaderLeft: () => null,
+}));
+
+jest.mock('@/lib/context', () => ({
+  AppContext: require('react').createContext({
+    lnInvoiceExpirySecs: 3600,
+    setLnInvoiceExpirySecs: jest.fn(),
+  }),
+}));
+
+import { AppContext } from '@/lib/context';
+
+import LnInvoiceExpiryScreen from '../ln-invoice-expiry';
+
+const mockSetLnInvoiceExpirySecs = jest.fn();
+
+const renderWithContext = (lnInvoiceExpirySecs: number) =>
+  setup(
+    <AppContext.Provider value={{ lnInvoiceExpirySecs, setLnInvoiceExpirySecs: mockSetLnInvoiceExpirySecs } as any}>
+      <LnInvoiceExpiryScreen />
+    </AppContext.Provider>,
+  );
+
+afterEach(() => {
+  cleanup();
+  jest.clearAllMocks();
+});
+
+describe('LnInvoiceExpiryScreen', () => {
+  it('renders all expiry presets', () => {
+    renderWithContext(3600);
+
+    expect(screen.getByText('lnInvoiceExpiry.options.tenMinutes')).toBeOnTheScreen();
+    expect(screen.getByText('lnInvoiceExpiry.options.thirtyMinutes')).toBeOnTheScreen();
+    expect(screen.getByText('lnInvoiceExpiry.options.oneHour')).toBeOnTheScreen();
+    expect(screen.getByText('lnInvoiceExpiry.options.sixHours')).toBeOnTheScreen();
+    expect(screen.getByText('lnInvoiceExpiry.options.oneDay')).toBeOnTheScreen();
+    expect(screen.getByText('lnInvoiceExpiry.options.sevenDays')).toBeOnTheScreen();
+    expect(screen.getByText('lnInvoiceExpiry.info_text')).toBeOnTheScreen();
+  });
+
+  it('marks only the stored value as selected and flags the default preset', () => {
+    renderWithContext(3600);
+
+    expect(screen.getAllByText('checkmark-circle')).toHaveLength(1);
+    expect(screen.getByText('lnInvoiceExpiry.default_hint')).toBeOnTheScreen();
+    expect(screen.getByTestId('ln-invoice-expiry-option-3600')).toHaveTextContent(/checkmark-circle/);
+  });
+
+  it('moves the checkmark to the stored non-default value', () => {
+    renderWithContext(600);
+
+    expect(screen.getAllByText('checkmark-circle')).toHaveLength(1);
+    expect(screen.getByTestId('ln-invoice-expiry-option-600')).toHaveTextContent(/checkmark-circle/);
+    expect(screen.getByTestId('ln-invoice-expiry-option-3600')).not.toHaveTextContent(/checkmark-circle/);
+  });
+
+  it('shows no checkmark when the stored value matches no preset', () => {
+    renderWithContext(1234);
+
+    expect(screen.queryByText('checkmark-circle')).toBeNull();
+  });
+
+  it('persists the selected preset in seconds when pressed', async () => {
+    const { user } = renderWithContext(3600);
+
+    await user.press(screen.getByText('lnInvoiceExpiry.options.sevenDays'));
+    expect(mockSetLnInvoiceExpirySecs).toHaveBeenCalledWith(604800);
+
+    await user.press(screen.getByText('lnInvoiceExpiry.options.tenMinutes'));
+    expect(mockSetLnInvoiceExpirySecs).toHaveBeenCalledWith(600);
+  });
+});

--- a/src/app/settings/ln-invoice-expiry.tsx
+++ b/src/app/settings/ln-invoice-expiry.tsx
@@ -1,0 +1,94 @@
+/* eslint-disable no-secrets/no-secrets */
+/* eslint-disable react/no-unstable-nested-components */
+/* eslint-disable react-native/no-inline-styles */
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { Stack } from 'expo-router';
+import React, { useCallback, useContext, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+
+import { HeaderLeft } from '@/components/back-button';
+import { HeaderTitle } from '@/components/header-title';
+import { colors, FocusAwareStatusBar, Pressable, SafeAreaView, Text, View } from '@/components/ui';
+import { DEFAULT_LN_INVOICE_EXPIRY_SECS, LN_INVOICE_EXPIRY_OPTIONS } from '@/lib/constant';
+import { AppContext } from '@/lib/context';
+
+interface ExpiryOptionProps {
+  title: string;
+  description?: string;
+  seconds: number;
+  isSelected: boolean;
+  onSelect: (seconds: number) => void;
+}
+
+const ExpiryOption = React.memo<ExpiryOptionProps>(({ title, description, seconds, isSelected, onSelect }) => {
+  const handlePress = useCallback(() => onSelect(seconds), [onSelect, seconds]);
+
+  return (
+    <Pressable onPress={handlePress} style={{ opacity: 1 }} testID={`ln-invoice-expiry-option-${seconds}`}>
+      <View className="flex min-h-[56px] flex-row items-center justify-between border-b-[0.5px] border-gray-300 px-2 py-4">
+        <View className="flex-1 pr-4">
+          <Text className="text-sm font-medium text-gray-900 dark:text-charcoal-100">{title}</Text>
+          {description ? <Text className="mt-1 text-xs leading-4 text-gray-500 dark:text-charcoal-400">{description}</Text> : null}
+        </View>
+        <View className="size-6 shrink-0 items-center justify-center">{isSelected && <Ionicons name="checkmark-circle" size={20} color={colors.primary[600]} />}</View>
+      </View>
+    </Pressable>
+  );
+});
+
+ExpiryOption.displayName = 'ExpiryOption';
+
+export default function LnInvoiceExpiryScreen() {
+  const { t } = useTranslation();
+  const { lnInvoiceExpirySecs, setLnInvoiceExpirySecs } = useContext(AppContext);
+
+  const handleSelect = useCallback(
+    (seconds: number) => {
+      setLnInvoiceExpirySecs(seconds);
+    },
+    [setLnInvoiceExpirySecs],
+  );
+
+  const expiryOptions = useMemo(
+    () =>
+      LN_INVOICE_EXPIRY_OPTIONS.map((option) => ({
+        key: option.key,
+        seconds: option.seconds,
+        title: t(`lnInvoiceExpiry.options.${option.key}`),
+        description: option.seconds === DEFAULT_LN_INVOICE_EXPIRY_SECS ? t('lnInvoiceExpiry.default_hint') : undefined,
+        isSelected: lnInvoiceExpirySecs === option.seconds,
+      })),
+    [t, lnInvoiceExpirySecs],
+  );
+
+  const screenOptions = useMemo(
+    () => ({
+      headerTitleAlign: 'center' as const,
+      headerTitle: () => <HeaderTitle title={t('lnInvoiceExpiry.header_title')} />,
+      headerShown: true,
+      headerShadowVisible: false,
+      headerLeft: HeaderLeft,
+    }),
+    [t],
+  );
+
+  return (
+    <SafeAreaProvider>
+      <SafeAreaView className="flex-1 bg-white dark:bg-charcoal-950">
+        <View className="flex h-full px-4">
+          <Stack.Screen options={screenOptions} />
+          <FocusAwareStatusBar />
+          <View className="mt-4">
+            {expiryOptions.map((option) => (
+              <ExpiryOption key={option.key} title={option.title} description={option.description} seconds={option.seconds} isSelected={option.isSelected} onSelect={handleSelect} />
+            ))}
+          </View>
+          <View className="mt-6 px-2">
+            <Text className="text-xs leading-5 text-gray-500 dark:text-charcoal-400">{t('lnInvoiceExpiry.info_text')}</Text>
+          </View>
+        </View>
+      </SafeAreaView>
+    </SafeAreaProvider>
+  );
+}

--- a/src/components/__tests__/screen-capture-guard.test.tsx
+++ b/src/components/__tests__/screen-capture-guard.test.tsx
@@ -38,6 +38,8 @@ function renderGuard(preventScreenCapture: boolean, isDataLoaded = true) {
           isoCode: 'CM',
         },
         bitcoinUnit: BitcoinUnit.Sats,
+        lnInvoiceExpirySecs: 3600,
+        setLnInvoiceExpirySecs: jest.fn(),
         setHideBalance: jest.fn(),
         setPreventScreenCapture: jest.fn(),
         setOnboarding: jest.fn(),

--- a/src/lib/constant.ts
+++ b/src/lib/constant.ts
@@ -35,3 +35,25 @@ export const DEFAULT_ESPLORA_SERVERS: EsploraServer[] = [
 ];
 
 export const GRIMM_APP_LN_URL_DOMAIN = 'pay.usegrimm.app';
+
+/** Default expiry (in seconds) applied to Lightning invoices generated via the Breez SDK. */
+export const DEFAULT_LN_INVOICE_EXPIRY_SECS = 3600;
+
+export type LnInvoiceExpiryOptionKey = 'tenMinutes' | 'thirtyMinutes' | 'oneHour' | 'sixHours' | 'oneDay' | 'sevenDays';
+
+export interface LnInvoiceExpiryOption {
+  key: LnInvoiceExpiryOptionKey;
+  seconds: number;
+}
+
+/** Presets offered in Settings for the Lightning invoice expiry duration. */
+export const LN_INVOICE_EXPIRY_OPTIONS: ReadonlyArray<LnInvoiceExpiryOption> = [
+  { key: 'tenMinutes', seconds: 10 * 60 },
+  { key: 'thirtyMinutes', seconds: 30 * 60 },
+  { key: 'oneHour', seconds: 60 * 60 },
+  { key: 'sixHours', seconds: 6 * 60 * 60 },
+  { key: 'oneDay', seconds: 24 * 60 * 60 },
+  { key: 'sevenDays', seconds: 7 * 24 * 60 * 60 },
+];
+
+export const isValidLnInvoiceExpirySecs = (value: unknown): value is number => typeof value === 'number' && Number.isInteger(value) && value > 0;

--- a/src/lib/context/app-context-provider.tsx
+++ b/src/lib/context/app-context-provider.tsx
@@ -3,6 +3,7 @@ import type { PropsWithChildren } from 'react';
 import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
 
 import type { Country } from '@/interfaces';
+import { DEFAULT_LN_INVOICE_EXPIRY_SECS, isValidLnInvoiceExpirySecs } from '@/lib/constant';
 import { useSecureStorage } from '@/lib/hooks';
 import { clearAllNotificationDeviceData } from '@/lib/notifications/device-storage';
 import { resetAppDatabase } from '@/lib/sqlite/database';
@@ -19,6 +20,7 @@ type defaultContextType = {
   isSeedPhraseBackup: boolean;
   selectedCountry: Country;
   bitcoinUnit: BitcoinUnit;
+  lnInvoiceExpirySecs: number;
   setHideBalance: (hideBalance: boolean) => void;
   setPreventScreenCapture: (preventScreenCapture: boolean) => void;
   setOnboarding: (onboarding: boolean) => void;
@@ -27,6 +29,7 @@ type defaultContextType = {
   setIsSeedPhraseBackup: (isSeedPhraseBackup: boolean) => void;
   setSelectedCountry: (country: Country) => void;
   setBitcoinUnit: (unit: BitcoinUnit) => void;
+  setLnInvoiceExpirySecs: (secs: number) => void;
 };
 
 const defaultContext: defaultContextType = {
@@ -46,6 +49,7 @@ const defaultContext: defaultContextType = {
     isoCode: 'CM',
   },
   bitcoinUnit: BitcoinUnit.Sats,
+  lnInvoiceExpirySecs: DEFAULT_LN_INVOICE_EXPIRY_SECS,
   setHideBalance: () => {},
   setPreventScreenCapture: () => {},
   setOnboarding: () => {},
@@ -54,6 +58,7 @@ const defaultContext: defaultContextType = {
   setIsSeedPhraseBackup: () => {},
   setSelectedCountry: () => {},
   setBitcoinUnit: () => {},
+  setLnInvoiceExpirySecs: () => {},
 };
 
 export const AppContext = createContext<defaultContextType>(defaultContext);
@@ -70,6 +75,7 @@ export const AppContextProvider = ({ children }: Props) => {
   const [isSeedPhraseBackup, _setIsSeedPhraseBackup] = useState(defaultContext.isSeedPhraseBackup);
   const [selectedCountry, _setSelectedCountry] = useState<Country>(defaultContext.selectedCountry);
   const [bitcoinUnit, _setBitcoinUnit] = useState<BitcoinUnit>(defaultContext.bitcoinUnit);
+  const [lnInvoiceExpirySecs, _setLnInvoiceExpirySecs] = useState<number>(defaultContext.lnInvoiceExpirySecs);
 
   const { getItem: _getHideBalance, setItem: _updateHideBalance } = useAsyncStorage('hideBalance');
   const { getItem: _getPreventScreenCapture, setItem: _updatePreventScreenCapture } = useAsyncStorage('preventScreenCapture');
@@ -78,6 +84,7 @@ export const AppContextProvider = ({ children }: Props) => {
   const { getItem: _getSeedPhrase, setItem: _updateSeedPhrase, deleteItem: _deleteSeedPhrase } = useSecureStorage('seedPhrase');
   const { getItem: _getIsSeedPhraseBackup, setItem: _updateIsSeedPhraseBackup } = useAsyncStorage('isSeedPhraseBackup');
   const { getItem: _getBitcoinUnit, setItem: _updateBitcoinUnit } = useAsyncStorage('bitcoinUnit');
+  const { getItem: _getLnInvoiceExpirySecs, setItem: _updateLnInvoiceExpirySecs } = useAsyncStorage('lnInvoiceExpirySecs');
 
   const _loadHideBalance = useCallback(async () => {
     const ob = await _getHideBalance();
@@ -126,10 +133,18 @@ export const AppContextProvider = ({ children }: Props) => {
     }
   }, [_getBitcoinUnit, _setBitcoinUnit]);
 
+  const _loadLnInvoiceExpirySecs = useCallback(async () => {
+    const ob = await _getLnInvoiceExpirySecs();
+    if (ob !== null) {
+      const parsed: unknown = JSON.parse(ob);
+      _setLnInvoiceExpirySecs(isValidLnInvoiceExpirySecs(parsed) ? parsed : DEFAULT_LN_INVOICE_EXPIRY_SECS);
+    }
+  }, [_getLnInvoiceExpirySecs, _setLnInvoiceExpirySecs]);
+
   useEffect(() => {
     const loadData = async () => {
       try {
-        await Promise.all([_loadHideBalance(), _loadPreventScreenCapture(), _loadOnboarding(), _loadSelectedCountry(), _loadSeedPhrase(), _loadIsSeedPhraseBackup(), _loadBitcoinUnit()]);
+        await Promise.all([_loadHideBalance(), _loadPreventScreenCapture(), _loadOnboarding(), _loadSelectedCountry(), _loadSeedPhrase(), _loadIsSeedPhraseBackup(), _loadBitcoinUnit(), _loadLnInvoiceExpirySecs()]);
       } catch (error) {
         console.error('Error loading data:', error);
       } finally {
@@ -138,7 +153,7 @@ export const AppContextProvider = ({ children }: Props) => {
     };
 
     loadData();
-  }, [_loadHideBalance, _loadPreventScreenCapture, _loadOnboarding, _loadSelectedCountry, _loadSeedPhrase, _loadIsSeedPhraseBackup, _loadBitcoinUnit]);
+  }, [_loadHideBalance, _loadPreventScreenCapture, _loadOnboarding, _loadSelectedCountry, _loadSeedPhrase, _loadIsSeedPhraseBackup, _loadBitcoinUnit, _loadLnInvoiceExpirySecs]);
 
   const setOnboarding = useCallback(
     async (arg: boolean) => {
@@ -231,6 +246,19 @@ export const AppContextProvider = ({ children }: Props) => {
     [_setBitcoinUnit, _updateBitcoinUnit],
   );
 
+  const setLnInvoiceExpirySecs = useCallback(
+    async (arg: number) => {
+      try {
+        await _setLnInvoiceExpirySecs(arg);
+        await _updateLnInvoiceExpirySecs(JSON.stringify(arg));
+      } catch (e) {
+        console.error(`[AsyncStorage] (lnInvoiceExpirySecs) Error saving data: ${e} [${arg}]`);
+        throw new Error('Error setting lnInvoiceExpirySecs');
+      }
+    },
+    [_setLnInvoiceExpirySecs, _updateLnInvoiceExpirySecs],
+  );
+
   const resetAppData = useCallback(async () => {
     try {
       await resetAppDatabase();
@@ -239,12 +267,13 @@ export const AppContextProvider = ({ children }: Props) => {
       _setHasSeedPhrase(false);
       await setIsSeedPhraseBackup(false);
       await setBitcoinUnit(BitcoinUnit.Sats);
+      await setLnInvoiceExpirySecs(DEFAULT_LN_INVOICE_EXPIRY_SECS);
       await clearAllNotificationDeviceData();
     } catch (e) {
       console.error('[AsyncStorage] (Reset app data) Error resetting:', e);
       throw new Error('Unable to reset app data');
     }
-  }, [setOnboarding, _deleteSeedPhrase, setIsSeedPhraseBackup, setBitcoinUnit]);
+  }, [setOnboarding, _deleteSeedPhrase, setIsSeedPhraseBackup, setBitcoinUnit, setLnInvoiceExpirySecs]);
 
   return (
     <AppContext.Provider
@@ -257,6 +286,7 @@ export const AppContextProvider = ({ children }: Props) => {
         isSeedPhraseBackup,
         selectedCountry,
         bitcoinUnit,
+        lnInvoiceExpirySecs,
         setHideBalance,
         setPreventScreenCapture,
         setOnboarding,
@@ -265,6 +295,7 @@ export const AppContextProvider = ({ children }: Props) => {
         setIsSeedPhraseBackup,
         setSelectedCountry,
         setBitcoinUnit,
+        setLnInvoiceExpirySecs,
       }}
     >
       {children}

--- a/src/lib/context/breez-context.tsx
+++ b/src/lib/context/breez-context.tsx
@@ -39,7 +39,7 @@ import type { ReactNode } from 'react';
 import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
 
 import { logUnclaimedDeposits } from '../breez/unclaimed-deposits-log';
-import { GRIMM_APP_LN_URL_DOMAIN } from '../constant';
+import { DEFAULT_LN_INVOICE_EXPIRY_SECS, GRIMM_APP_LN_URL_DOMAIN } from '../constant';
 import { useSecureStorage } from '../hooks/use-secure-storage';
 
 export enum AppNetwork {
@@ -403,7 +403,7 @@ export const BreezProvider: React.FC<BreezProviderProps> = ({ children }) => {
       paymentMethod: ReceivePaymentMethod.Bolt11Invoice.new({
         description,
         amountSats: amountSats !== undefined ? BigInt(amountSats) : undefined,
-        expirySecs: expirySecs ?? 3600,
+        expirySecs: expirySecs ?? DEFAULT_LN_INVOICE_EXPIRY_SECS,
         paymentHash: undefined,
       }),
     });

--- a/src/lib/hooks/__tests__/use-countdown.test.ts
+++ b/src/lib/hooks/__tests__/use-countdown.test.ts
@@ -1,0 +1,115 @@
+import { act, renderHook } from '@testing-library/react-native';
+
+import { formatRemainingTime, useCountdown } from '../use-countdown';
+
+describe('formatRemainingTime', () => {
+  it.each([
+    [0, '0:00'],
+    [59, '0:59'],
+    [60, '1:00'],
+    [600, '10:00'],
+    [3599, '59:59'],
+    [3600, '1:00:00'],
+    [3661, '1:01:01'],
+    [86399, '23:59:59'],
+    [604800, '168:00:00'],
+  ])('formats %i seconds as %s', (input, expected) => {
+    expect(formatRemainingTime(input)).toBe(expected);
+  });
+
+  it('clamps negative values to zero', () => {
+    expect(formatRemainingTime(-5)).toBe('0:00');
+  });
+
+  it('floors fractional seconds', () => {
+    expect(formatRemainingTime(61.9)).toBe('1:01');
+  });
+});
+
+describe('useCountdown', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns null remaining time when no deadline is set', () => {
+    const { result } = renderHook(() => useCountdown(null));
+
+    expect(result.current.remainingSecs).toBeNull();
+    expect(result.current.isExpired).toBe(false);
+  });
+
+  it('counts down every second until the deadline', () => {
+    const expiresAt = Date.now() + 3000;
+    const { result } = renderHook(() => useCountdown(expiresAt));
+
+    expect(result.current.remainingSecs).toBe(3);
+    expect(result.current.isExpired).toBe(false);
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(result.current.remainingSecs).toBe(2);
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+    expect(result.current.remainingSecs).toBe(0);
+    expect(result.current.isExpired).toBe(true);
+  });
+
+  it('never goes below zero once the deadline has passed', () => {
+    const expiresAt = Date.now() + 1000;
+    const { result } = renderHook(() => useCountdown(expiresAt));
+
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    expect(result.current.remainingSecs).toBe(0);
+    expect(result.current.isExpired).toBe(true);
+  });
+
+  it('resets when the deadline is cleared', () => {
+    const { result, rerender } = renderHook(({ expiresAt }: { expiresAt: number | null }) => useCountdown(expiresAt), {
+      initialProps: { expiresAt: Date.now() + 10000 } as { expiresAt: number | null },
+    });
+
+    expect(result.current.remainingSecs).toBe(10);
+
+    rerender({ expiresAt: null });
+
+    expect(result.current.remainingSecs).toBeNull();
+    expect(result.current.isExpired).toBe(false);
+  });
+
+  it('restarts from a new deadline', () => {
+    const { result, rerender } = renderHook(({ expiresAt }: { expiresAt: number | null }) => useCountdown(expiresAt), {
+      initialProps: { expiresAt: Date.now() + 2000 } as { expiresAt: number | null },
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+    expect(result.current.isExpired).toBe(true);
+
+    rerender({ expiresAt: Date.now() + 30000 });
+
+    expect(result.current.remainingSecs).toBe(30);
+    expect(result.current.isExpired).toBe(false);
+  });
+
+  it('clears the interval on unmount', () => {
+    const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
+    const { unmount } = renderHook(() => useCountdown(Date.now() + 5000));
+
+    unmount();
+
+    expect(clearIntervalSpy).toHaveBeenCalled();
+    clearIntervalSpy.mockRestore();
+  });
+});

--- a/src/lib/hooks/index.tsx
+++ b/src/lib/hooks/index.tsx
@@ -1,2 +1,3 @@
+export * from './use-countdown';
 export * from './use-secure-storage';
 export * from './use-selected-theme';

--- a/src/lib/hooks/use-countdown.ts
+++ b/src/lib/hooks/use-countdown.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Formats a remaining duration (in seconds) as `h:mm:ss` when at least one hour remains, otherwise `m:ss`.
+ * Negative or fractional inputs are clamped/floored to whole seconds.
+ */
+export const formatRemainingTime = (remainingSecs: number): string => {
+  const total = Math.max(0, Math.floor(remainingSecs));
+  const hours = Math.floor(total / 3600);
+  const minutes = Math.floor((total % 3600) / 60);
+  const seconds = total % 60;
+  const mm = minutes.toString().padStart(2, '0');
+  const ss = seconds.toString().padStart(2, '0');
+  return hours > 0 ? `${hours}:${mm}:${ss}` : `${minutes}:${ss}`;
+};
+
+/**
+ * Ticks every second until `expiresAt` (epoch milliseconds) is reached.
+ * Returns `remainingSecs: null` when no deadline is set.
+ */
+export const useCountdown = (expiresAt: number | null) => {
+  const [remainingSecs, setRemainingSecs] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (expiresAt === null) {
+      setRemainingSecs(null);
+      return;
+    }
+
+    const tick = () => setRemainingSecs(Math.max(0, Math.ceil((expiresAt - Date.now()) / 1000)));
+
+    tick();
+    const interval = setInterval(tick, 1000);
+
+    return () => clearInterval(interval);
+  }, [expiresAt]);
+
+  return { remainingSecs, isExpired: remainingSecs !== null && remainingSecs <= 0 };
+};

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -213,6 +213,19 @@
       "updated": "Lightning Address updated successfully!"
     }
   },
+  "lnInvoiceExpiry": {
+    "default_hint": "Default",
+    "header_title": "Invoice Expiry",
+    "info_text": "New Lightning invoices you generate will expire after this duration. An expired invoice can no longer be paid; generate a new one instead.",
+    "options": {
+      "oneDay": "24 hours",
+      "oneHour": "1 hour",
+      "sevenDays": "7 days",
+      "sixHours": "6 hours",
+      "tenMinutes": "10 minutes",
+      "thirtyMinutes": "30 minutes"
+    }
+  },
   "lnPaymentMethod": {
     "lightningDescription": "Fast & low fees",
     "receiveTitle": "Receive via Lightning Network",
@@ -564,6 +577,10 @@
       "lnAddress": {
         "subtitle": "Manage and configure your Lightning Network address",
         "title": "LN Address"
+      },
+      "lnInvoiceExpiry": {
+        "subtitle": "Choose how long Lightning invoices stay valid",
+        "title": "Invoice Expiry"
       },
       "networks": {
         "subtitle": "Manage and configure your networks",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -213,6 +213,19 @@
       "updated": "Adresse Lightning mise à jour avec succès !"
     }
   },
+  "lnInvoiceExpiry": {
+    "default_hint": "Par défaut",
+    "header_title": "Expiration des factures",
+    "info_text": "Les nouvelles factures Lightning que vous générez expireront après cette durée. Une facture expirée ne peut plus être payée ; générez-en une nouvelle.",
+    "options": {
+      "oneDay": "24 heures",
+      "oneHour": "1 heure",
+      "sevenDays": "7 jours",
+      "sixHours": "6 heures",
+      "tenMinutes": "10 minutes",
+      "thirtyMinutes": "30 minutes"
+    }
+  },
   "lnPaymentMethod": {
     "lightningDescription": "Rapide & frais réduits",
     "receiveTitle": "Recevoir via le réseau Lightning",
@@ -564,6 +577,10 @@
       "lnAddress": {
         "subtitle": "Gérez et configurez votre adresse Lightning Network",
         "title": "Adresse LN"
+      },
+      "lnInvoiceExpiry": {
+        "subtitle": "Choisissez la durée de validité des factures Lightning",
+        "title": "Expiration des factures"
       },
       "networks": {
         "subtitle": "Gérez et configurez vos réseaux",


### PR DESCRIPTION
Closes #188

## What does this do?

Lets users choose how long the Lightning invoices they generate stay valid, instead of the hard-coded 1 hour.

- **New setting — Settings › General › Invoice Expiry** (`src/app/settings/ln-invoice-expiry.tsx`): a preset list (10 min, 30 min, 1 h *(default)*, 6 h, 24 h, 7 days), same look and behaviour as the Bitcoin Unit screen (tap = saved immediately, checkmark on the active value).
- **Persisted preference** `lnInvoiceExpirySecs` in `AppContext` (`src/lib/context/app-context-provider.tsx`), stored in AsyncStorage, validated on load (falls back to the default if the stored value is not a positive integer) and reset to the default on logout via `resetAppData`.
- **Applied to invoice generation**: `src/app/receive/ln-qrcode.tsx` now passes the configured value to `receiveBolt11`, which forwards it as `expirySecs` to the Breez SDK `receivePayment` call. The literal `3600` in `breez-context.tsx` is replaced by `DEFAULT_LN_INVOICE_EXPIRY_SECS` (`src/lib/constant.ts`).
- **Receive QR screen**: shows an **"expires in h:mm:ss"** countdown under the amount for Lightning invoices. When the invoice expires, the QR code is hidden, copy/share are disabled and a **Retry** button regenerates a fresh invoice with a new countdown. On-chain receive is unchanged (no countdown).
- **Shared hook** `useCountdown` + `formatRemainingTime` (`src/lib/hooks/use-countdown.ts`), exported through `@/lib`.
- **Translations** (en/fr): `settings.general.lnInvoiceExpiry.*` for the settings row and a new `lnInvoiceExpiry.*` namespace for the screen. The countdown reuses the existing `paymentDetails.expiresIn` / `paymentDetails.expired` keys.

## Why did you do this?

Invoices generated via the Breez SDK always expired after 1 hour (#188). Some users need a shorter window (point-of-sale style, invoice shared once) and others a longer one (invoice sent by message and paid later). Design choices:

- **Preset list rather than a free-form input** — no validation UX to build, consistent with the other settings screens, and the presets cover the realistic range. The value is stored as raw seconds (not an enum) so new presets can be added without a storage migration, and the SDK field (`expirySecs: u32`) is used as-is.
- **The caller passes the expiry** — `breez-context` stays a thin SDK wrapper; the preference lives in `AppContext` like every other user setting.
- **Countdown on the QR screen** — the SDK response does not echo the expiry back, so the deadline is computed locally when the invoice is created. It makes the setting visible to the user and avoids sharing an invoice that can no longer be paid.
- `send/transaction-details.tsx` keeps its own inline countdown; refactoring it onto the new hook is a possible follow-up but was left out to keep this PR focused.

## Who/what does this impact?

- **Users**: new settings row; the Lightning receive screen gains a countdown and an "expired" state. Default behaviour is unchanged (1 hour) for existing installs — no stored value means the default is used.
- **`AppContext` consumers**: two new members (`lnInvoiceExpirySecs`, `setLnInvoiceExpirySecs`). Any test that builds a full `AppContext` value must include them (`screen-capture-guard.test.tsx` was updated).
- **`useBreez().receiveBolt11`**: signature unchanged; only the fallback default moved to a constant.
- **Storage**: new AsyncStorage key `lnInvoiceExpirySecs`. Reset on logout alongside the other preferences.
- No native / dependency changes. No impact on on-chain receive or the send flow.

## How did you test this?

Automated (`pnpm lint`, `pnpm type-check`, `pnpm lint:translations`, `pnpm test` — 45 suites / 331 tests green):

- `src/lib/hooks/__tests__/use-countdown.test.ts` — `formatRemainingTime` formatting (`0:00`, `59:59`, `1:00:00`, `168:00:00`, clamping), hook ticking with fake timers, expiry, reset when the deadline is cleared, restart on a new deadline, interval cleanup.
- `src/app/settings/__tests__/ln-invoice-expiry.test.tsx` — all six presets rendered, single checkmark on the stored value, "Default" hint on 1 h, no checkmark for an unknown value, pressing a preset calls `setLnInvoiceExpirySecs` with the right number of seconds.
- `src/app/receive/__tests__/ln-qrcode.test.tsx` — `receiveBolt11` receives the configured expiry (1800 / 3600), countdown shows `30:00` and ticks down, expired state hides the QR and Retry regenerates (second `receiveBolt11` call + fresh countdown), on-chain receive shows no countdown and never calls `receiveBolt11`, invalid amount shows the error state.

Manual checklist (device / simulator):

- [ ] Settings › Invoice Expiry shows 1 h selected by default; pick 10 min, kill and relaunch the app → selection persists.
- [ ] Receive › Lightning › QR shows "expires in 10:00" counting down; decode the invoice (external decoder or `parseInput`) → `expiry` = 600.
- [ ] Let the invoice expire → "Expired", QR hidden, copy/share disabled, Retry produces a new invoice with a new countdown.
- [ ] On-chain receive: no countdown.
- [ ] Log out → setting back to 1 h.
- [ ] fr locale: settings row, screen and presets are translated.